### PR TITLE
[Ci] CI/CD Docker 기반 자동 배포 환경 구성

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,0 +1,43 @@
+name: Docker CI/CD Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/springboot-app:latest
+
+      - name: SSH to server and run container
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.KEY }}
+          port: ${{ secrets.PORT }}
+          script: |
+            docker pull ${{ secrets.DOCKER_USERNAME }}/springboot-app:latest
+            docker stop springboot-app || true
+            docker rm springboot-app || true
+            docker run -d -p 8080:8080 --name springboot-app ${{ secrets.DOCKER_USERNAME }}/springboot-app:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:17-jdk
+
+ARG JAR_FILE=build/libs/*.jar
+
+COPY ${JAR_FILE} app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #3 

## 📝작업 내용
- `Dockerfile` 작성 및 테스트
- GitHub Actions 워크플로우(`docker-deploy.yml`) 작성
  - push 이벤트 발생 시 DockerHub에 이미지 업로드
  - 서버 접속 후 컨테이너 pull & run 자동화
- GitHub Secrets 등록 (`DOCKER_USERNAME`, `DOCKER_PASSWORD`, `HOST`, `USERNAME`, `PORT`, `KEY`)
- NCP 서버에 Docker 설치 및 설정
- ACG에서 `8080` 포트 개방
- 로컬에서 `./gradlew build`로 빌드 테스트 완료


🙌 추후 도메인 연결 및 HTTPS 적용 예정입니다.
