### PR TITLE
[CI] #3: submodule로 등록된 secret 레포 접근을 위한 토근 발급 및 설정

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #3

## 📝작업 내용

> secret 레포 접근을 위한 GitHub Personal Access Token 생성하여 GitHub Actions에 Secret으로 등록
> Actions 워크플로우에 적용

