### PR TITLE
[FEAT] 가게 입점 등록 및 기본 정보/운영 시간 등록 기능 구현

### DIFF
--- a/src/main/java/com/deark/be/store/controller/StoreController.java
+++ b/src/main/java/com/deark/be/store/controller/StoreController.java
@@ -1,9 +1,25 @@
 package com.deark.be.store.controller;
 
+import static com.deark.be.global.dto.ResponseTemplate.EMPTY_RESPONSE;
+
+import com.deark.be.global.dto.ResponseTemplate;
+import com.deark.be.store.dto.request.StoreBasicInfoRequest;
+import com.deark.be.store.dto.request.StoreRegisterRequest;
+import com.deark.be.store.service.StoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Store", description = "가게 관련 API")
@@ -12,4 +28,31 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/store")
 public class StoreController {
+    private final StoreService storeService;
+
+    @PostMapping(value = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "가게 입점 등록", description = """
+        S3에 미리 업로드된 파일 URL을 기반으로 가게 입점 정보를 등록합니다.
+        """)
+    public ResponseEntity<ResponseTemplate<Object>> registerStore(
+            @ModelAttribute @Valid StoreRegisterRequest request,
+            @Parameter(description = "사용자 ID", example = "1")
+            @RequestParam Long userId
+    ) {
+        Long storeId = storeService.registerStore(request, userId);
+        return ResponseEntity
+                .ok(ResponseTemplate.from(storeId));
+    }
+
+    @PostMapping("/basic-info")
+    @Operation(summary = "가게 기본 정보 등록", description = "입점 후, 기본정보 및 영업시간을 등록합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> registerStoreBasicInfo(
+            @RequestParam Long storeId,
+            @RequestBody StoreBasicInfoRequest request
+    ) {
+        storeService.registerStoreBasicInfo(storeId, request);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(EMPTY_RESPONSE);
+    }
 }

--- a/src/main/java/com/deark/be/store/domain/Store.java
+++ b/src/main/java/com/deark/be/store/domain/Store.java
@@ -28,7 +28,7 @@ public class Store extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name")
     private String name;
 
     @Column(name = "description")
@@ -55,11 +55,30 @@ public class Store extends BaseTimeEntity {
     @Column(name = "chatting_url")
     private String chattingUrl;
 
-    @Column(name = "is_unmanned", nullable = false)
+    @Column(name = "is_unmanned")
     private Boolean isUnmanned;
 
-    @Column(name = "is_same_day_order", nullable = false)
+    @Column(name = "is_same_day_order")
     private Boolean isSameDayOrder;
+
+    @Column(name = "business_license_url")
+    private String businessLicenseUrl;
+
+    @Column(name = "business_permit_url")
+    private String businessPermitUrl;
+
+
+    @Column(name = "settlement_account")
+    private String settlementAccount;
+
+    @Column(name = "owner_name")
+    private String ownerName;
+
+    @Column(name = "order_link")
+    private String orderLink;
+
+    @Column(name = "max_daily_orders")
+    private Integer maxDailyOrders;
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BusinessHours> businessHoursList = new ArrayList<>();
@@ -70,7 +89,9 @@ public class Store extends BaseTimeEntity {
     @Builder
     public Store(User user, String name, String description, String phone, String address,
                  String businessNumber, LocalDate establishDate, String imageUrl,
-                 Long averageResponseTime, String chattingUrl, Boolean isUnmanned, Boolean isSameDayOrder) {
+                 Long averageResponseTime, String chattingUrl, Boolean isUnmanned, Boolean isSameDayOrder
+                 ,String settlementAccount
+    ) {
         this.user = user;
         this.name = name;
         this.description = description;
@@ -83,6 +104,37 @@ public class Store extends BaseTimeEntity {
         this.chattingUrl = chattingUrl;
         this.isUnmanned = isUnmanned;
         this.isSameDayOrder = isSameDayOrder;
+        this.settlementAccount = settlementAccount;
+    }
+
+    public static Store createWithUrls(User user, String businessNumber, LocalDate establishDate,
+                                       String businessLicenseUrl, String businessPermitUrl,
+                                       String settlementAccount, String ownerName) {
+        Store store = new Store();
+        store.user = user;
+        store.businessNumber = businessNumber;
+        store.establishDate = establishDate;
+        store.businessLicenseUrl = businessLicenseUrl;
+        store.businessPermitUrl = businessPermitUrl;
+        store.settlementAccount = settlementAccount;
+        store.ownerName = ownerName;
+        return store;
+    }
+
+
+    // Store 엔티티 내에 추가할 메서드
+    public void updateBasicInfo(String name, String phone, String description, String address,
+                                String imageUrl, String chattingUrl, Boolean isUnmanned,
+                                String orderLink, Integer maxDailyOrders) {
+        this.name = name;
+        this.phone = phone;
+        this.description = description;
+        this.address = address;
+        this.imageUrl = imageUrl;
+        this.chattingUrl = chattingUrl;
+        this.isUnmanned = isUnmanned;
+        this.orderLink = orderLink;
+        this.maxDailyOrders = maxDailyOrders;
     }
 }
 

--- a/src/main/java/com/deark/be/store/dto/request/BusinessHoursRequest.java
+++ b/src/main/java/com/deark/be/store/dto/request/BusinessHoursRequest.java
@@ -1,0 +1,23 @@
+package com.deark.be.store.dto.request;
+
+import com.deark.be.store.domain.type.BusinessDay;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+
+@Schema(description = "영업시간 요청 DTO")
+public record BusinessHoursRequest(
+
+        @Schema(description = "요일", example = "MONDAY")
+        @NotNull BusinessDay businessDay,
+
+        @Schema(description = "영업 시작 시간", example = "09:00", pattern = "HH:mm")
+        @NotNull LocalTime openTime,
+
+        @Schema(description = "영업 종료 시간", example = "18:00", pattern = "HH:mm")
+        @NotNull LocalTime closeTime,
+
+        @Schema(description = "24시간 운영 여부", example = "false")
+        @NotNull Boolean isOpen24Hours
+
+) {}

--- a/src/main/java/com/deark/be/store/dto/request/StoreBasicInfoRequest.java
+++ b/src/main/java/com/deark/be/store/dto/request/StoreBasicInfoRequest.java
@@ -1,0 +1,41 @@
+package com.deark.be.store.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+@Schema(description = "가게 기본 정보 수정 요청 DTO")
+public record StoreBasicInfoRequest(
+
+        @Schema(description = "가게 이름", example = "이쁜케이크")
+        @NotBlank String name,
+
+        @Schema(description = "가게 전화번호", example = "010-1234-5678")
+        @NotBlank String phone,
+
+        @Schema(description = "가게 소개", example = "감성 케이크 가게입니다.")
+        @NotBlank String description,
+
+        @Schema(description = "가게 주소", example = "경기도 수원시 영통구")
+        @NotBlank String address,
+
+        @Schema(description = "대표 이미지 URL")
+        @NotBlank String imageUrl,
+
+        @Schema(description = "카카오톡 채팅 링크", example = "https://pf.kakao.com/_abcXj")
+        @NotBlank String chattingUrl,
+
+        @Schema(description = "무인 운영 여부", example = "false")
+        @NotNull Boolean isUnmanned,
+
+        @Schema(description = "주문 링크", example = "https://order.example.com")
+        @NotBlank String orderLink,
+
+        @Schema(description = "하루 최대 주문 수", example = "30")
+        @NotNull Integer maxDailyOrders,
+
+        @Schema(description = "영업시간 리스트")
+        @NotNull List<BusinessHoursRequest> businessHours
+
+) {}

--- a/src/main/java/com/deark/be/store/dto/request/StoreRegisterRequest.java
+++ b/src/main/java/com/deark/be/store/dto/request/StoreRegisterRequest.java
@@ -1,0 +1,37 @@
+package com.deark.be.store.dto.request;
+
+import com.deark.be.store.domain.Store;
+import com.deark.be.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "가게 입점 등록 요청 DTO")
+public record StoreRegisterRequest(
+
+        @Schema(description = "가게 개업일자 (yyyy-MM-dd)", example = "2024-05-01")
+        @NotNull LocalDate establishDate,
+
+        @Schema(description = "사업자 등록번호", example = "1234567890")
+        @NotBlank String businessNumber,
+
+        @Schema(description = "정산용 계좌번호", example = "110-123-456789")
+        @NotBlank String settlementAccount,
+
+        @Schema(description = "사업자등록증 파일", type = "string", format = "binary")
+        @NotNull MultipartFile businessLicenseFile,
+
+        @Schema(description = "영업신고증 파일", type = "string", format = "binary")
+        @NotNull MultipartFile businessPermitFile,
+
+        @Schema(description = "가게 이름", example = "이쁜케이크")
+        @NotBlank String ownerName
+
+) {
+        public Store toEntity(User user, String businessLicenseUrl, String businessPermitUrl) {
+                return Store.createWithUrls(user, businessNumber, establishDate, businessLicenseUrl, businessPermitUrl,
+                        settlementAccount, ownerName);
+        }
+}

--- a/src/main/java/com/deark/be/store/exception/errorcode/StoreErrorCode.java
+++ b/src/main/java/com/deark/be/store/exception/errorcode/StoreErrorCode.java
@@ -1,12 +1,13 @@
 package com.deark.be.store.exception.errorcode;
 
+import com.deark.be.global.exception.errorcode.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum StoreErrorCode {
+public enum StoreErrorCode implements ErrorCode {
 
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE400", "가게를 찾을 수 없습니다."),
     ;

--- a/src/main/java/com/deark/be/store/repository/BusinessHoursRepository.java
+++ b/src/main/java/com/deark/be/store/repository/BusinessHoursRepository.java
@@ -1,9 +1,11 @@
 package com.deark.be.store.repository;
 
 import com.deark.be.store.domain.BusinessHours;
+import com.deark.be.store.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BusinessHoursRepository extends JpaRepository<BusinessHours, Long> {
+    void deleteByStore(Store store);
 }

--- a/src/main/java/com/deark/be/store/service/BusinessHoursService.java
+++ b/src/main/java/com/deark/be/store/service/BusinessHoursService.java
@@ -1,0 +1,38 @@
+package com.deark.be.store.service;
+
+import com.deark.be.store.domain.BusinessHours;
+import com.deark.be.store.domain.Store;
+import com.deark.be.store.dto.request.BusinessHoursRequest;
+import com.deark.be.store.repository.BusinessHoursRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// BusinessHourService.java
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BusinessHoursService {
+
+    private final BusinessHoursRepository businessHoursRepository;
+
+    @Transactional
+    public void registerBusinessHours(Store store, List<BusinessHoursRequest> requests) {
+        businessHoursRepository.deleteByStore(store); // ✅ 모든 요일 데이터 삭제하고 재설정
+
+        List<BusinessHours> hours = requests.stream()
+                .map(r -> BusinessHours.builder()
+                        .store(store)
+                        .businessDay(r.businessDay())
+                        .openTime(r.openTime())
+                        .closeTime(r.closeTime())
+                        .isOpen24Hours(r.isOpen24Hours())
+                        .build())
+                .toList();
+
+        businessHoursRepository.saveAll(hours);
+    }
+}

--- a/src/main/java/com/deark/be/store/service/StoreService.java
+++ b/src/main/java/com/deark/be/store/service/StoreService.java
@@ -1,5 +1,17 @@
 package com.deark.be.store.service;
 
+import static com.deark.be.store.exception.errorcode.StoreErrorCode.STORE_NOT_FOUND;
+import static com.deark.be.user.exception.errorcode.UserErrorCode.USER_NOT_FOUND;
+
+import com.deark.be.global.service.S3Service;
+import com.deark.be.store.domain.Store;
+import com.deark.be.store.dto.request.StoreBasicInfoRequest;
+import com.deark.be.store.dto.request.StoreRegisterRequest;
+import com.deark.be.store.exception.StoreException;
+import com.deark.be.store.repository.StoreRepository;
+import com.deark.be.user.domain.User;
+import com.deark.be.user.exception.UserException;
+import com.deark.be.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,4 +22,35 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StoreService {
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+    private final BusinessHoursService businessHoursService;
+    private final S3Service s3Service;
+
+
+    @Transactional
+    public Long registerStore(StoreRegisterRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+        String businessLicenseUrl = s3Service.uploadFile(request.businessLicenseFile());
+        String businessPermitUrl = s3Service.uploadFile(request.businessPermitFile());
+
+        Store store = request.toEntity(user, businessLicenseUrl, businessPermitUrl);
+        return storeRepository.save(store).getId();
+    }
+
+    @Transactional
+    public void registerStoreBasicInfo(Long storeId, StoreBasicInfoRequest request) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(STORE_NOT_FOUND));
+
+
+        store.updateBasicInfo(
+                request.name(), request.phone(), request.description(), request.address(),
+                request.imageUrl(), request.chattingUrl(), request.isUnmanned(),
+                request.orderLink(), request.maxDailyOrders()
+        );
+
+        businessHoursService.registerBusinessHours(store, request.businessHours());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #21 

## 📝작업 내용
- 가게 입점 등록 기능 구현 (`/store/register`)
  - 사업자 등록증, 영업신고증 이미지 S3 업로드 후 DB 저장
  
- 가게 기본 정보 등록 기능 구현 (`/store/basic-info`)
  - 이름, 설명, 전화번호, 주소, 채팅링크, 주문링크 등 등록
  
- 영업 시간 등록 기능 추가
  - 운영 요일, 시작/종료 시간, 24시간 여부 설정 가능
 
- `Store` 엔티티 필드 추가 및 설정 변경
  - 기본 정보 및 영업 정보 관련 컬럼 추가, nullable이 fasle로 설정되어있는 일부 필드를 true로 변경

- `StoreRegisterRequest`, `StoreBasicInfoRequest`, `BusinessHoursRequest` 등 DTO 생성 및 검증 로직 추가

- `StoreErrorCode`가 `ErrorCode` 상속받도록 구조 정비

### 테스트 방법
- Swagger에서 multipart/form-data로 입점 및 기본 정보 등록 요청 테스트 완료
- 정상 응답 및 DB 저장 확인

