### PR TITLE
[FEAT] 이벤트 관련 api 개발

### DIFF
--- a/src/main/java/com/deark/be/event/controller/EventController.java
+++ b/src/main/java/com/deark/be/event/controller/EventController.java
@@ -137,18 +137,20 @@ public class EventController {
     @PutMapping("/design/mapping")
     @Operation(summary = "디자인-이벤트 일괄 매핑", description = "특정 디자인이 속한 이벤트들을 재설정합니다.")
     public ResponseEntity<ResponseTemplate<Object>> updateDesignMappings(
-            @RequestBody UpdateDesignMappingRequest request
+            @RequestBody UpdateDesignMappingRequest request,
+            @AuthenticationPrincipal Long userId
     ) {
-        eventDesignService.updateDesignEventMappings(request);
+        eventDesignService.updateDesignEventMappings(request,userId);
         return ResponseEntity.status(HttpStatus.OK).body(EMPTY_RESPONSE);
     }
 
     @PutMapping("/store/mapping")
     @Operation(summary = "스토어-이벤트 일괄 매핑", description = "특정 스토어가 속한 이벤트들을 재설정합니다.")
     public ResponseEntity<ResponseTemplate<Object>> updateStoreMappings(
-            @RequestBody UpdateStoreMappingRequest request
+            @RequestBody UpdateStoreMappingRequest request,
+            @AuthenticationPrincipal Long userId
     ) {
-        eventStoreService.updateStoreEventMappings(request);
+        eventStoreService.updateStoreEventMappings(request,userId);
         return ResponseEntity.status(HttpStatus.OK).body(EMPTY_RESPONSE);
     }
 

--- a/src/main/java/com/deark/be/event/controller/EventController.java
+++ b/src/main/java/com/deark/be/event/controller/EventController.java
@@ -1,9 +1,36 @@
 package com.deark.be.event.controller;
 
+import static com.deark.be.global.dto.ResponseTemplate.EMPTY_RESPONSE;
+
+import com.deark.be.event.dto.request.EventCreateRequest;
+import com.deark.be.event.dto.request.EventUpdateRequest;
+import com.deark.be.event.dto.request.UpdateDesignMappingRequest;
+import com.deark.be.event.dto.request.UpdateStoreMappingRequest;
+import com.deark.be.event.dto.response.DesignInEventResponse;
+import com.deark.be.event.dto.response.EventResponse;
+import com.deark.be.event.dto.response.EventWithCheckResponse;
+import com.deark.be.event.dto.response.StoreInEventResponse;
+import com.deark.be.event.service.EventDesignService;
+import com.deark.be.event.service.EventService;
+import com.deark.be.event.service.EventStoreService;
+import com.deark.be.global.dto.ResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Event", description = "이벤트 관련 API")
@@ -12,4 +39,138 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/event")
 public class EventController {
+    private final EventService eventService;
+    private final EventDesignService eventDesignService;
+    private final EventStoreService eventStoreService;
+
+    @GetMapping("/my_events")
+    @Operation(summary = "내 이벤트 전체목록 조회", description = "로그인한 사용자가 생성한 이벤트 전체목록을 조회합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> getMyEvents(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<EventResponse> events = eventService.getMyEvents(userId);
+        return ResponseEntity.ok(ResponseTemplate.from(events));
+    }
+
+    @GetMapping("/{eventId}")
+    @Operation(summary = "이벤트 상세 조회", description = "이벤트 ID로 해당 이벤트의 상세 정보(제목, 날짜, 주소)를 조회합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> getEventDetail(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        EventResponse response = eventService.getEventDetail(eventId, userId);
+        return ResponseEntity.ok(ResponseTemplate.from(response));
+    }
+
+    @GetMapping("/my_events/with-check/design")
+    @Operation(summary = "디자인 포함 여부와 함께 내 이벤트 목록 조회", description = "디자인이 포함되어 있는 이벤트를 표시합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> getMyEventsWithCheckForDesign(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam Long designId
+    ) {
+        List<EventWithCheckResponse> response = eventService.getMyEventsWithCheckForDesign(userId, designId);
+        return ResponseEntity.ok(ResponseTemplate.from(response));
+    }
+
+    @GetMapping("/my_events/with-check/store")
+    @Operation(summary = "스토어 포함 여부와 함께 내 이벤트 목록 조회", description = "스토어가 포함되어 있는 이벤트를 표시합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> getMyEventsWithCheckForStore(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam Long storeId
+    ) {
+        List<EventWithCheckResponse> response = eventService.getMyEventsWithCheckForStore(userId, storeId);
+        return ResponseEntity.ok(ResponseTemplate.from(response));
+    }
+
+    @PostMapping("")
+    @Operation(summary = "새 이벤트 생성", description = "새로운 이벤트를 생성합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> createEvent(
+            @Valid @RequestBody EventCreateRequest request,
+            @AuthenticationPrincipal Long userId
+    ){
+    Long eventId=eventService.createEvent(userId, request);
+    return ResponseEntity
+            .ok(ResponseTemplate.from(eventId));
+    }
+
+    @DeleteMapping("/{eventId}")
+    @Operation(summary = "이벤트 삭제", description = "이벤트를 삭제합니다. 관련된 디자인 및 스토어 연결도 제거됩니다.")
+    public ResponseEntity<ResponseTemplate<Object>> deleteEvent(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        eventService.deleteEvent(eventId, userId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(EMPTY_RESPONSE);
+    }
+
+    @PutMapping("/{eventId}")
+    @Operation(summary = "이벤트 수정", description = "이벤트 정보를 수정합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> updateEvent(
+            @PathVariable Long eventId,
+            @Valid @RequestBody EventUpdateRequest request,
+            @AuthenticationPrincipal Long userId
+    ) {
+        eventService.updateEvent(eventId, userId, request);
+        return ResponseEntity.status(HttpStatus.OK).body(EMPTY_RESPONSE);
+    }
+
+    @GetMapping("/{eventId}/designs")
+    @Operation(summary = "이벤트 내 디자인 목록 조회", description = "특정 이벤트에 포함된 모든 디자인 목록을 조회합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> getDesignsInEvent(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<DesignInEventResponse> result = eventService.getDesignsInEvent(eventId, userId);
+        return ResponseEntity.ok(ResponseTemplate.from(result));
+    }
+
+    @GetMapping("/{eventId}/stores")
+    @Operation(summary = "이벤트 내 스토어 목록 조회", description = "특정 이벤트에 포함된 모든 스토어 목록을 조회합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> getStoresInEvent(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<StoreInEventResponse> result = eventService.getStoresInEvent(eventId, userId);
+        return ResponseEntity.ok(ResponseTemplate.from(result));
+    }
+
+    @PutMapping("/design/mapping")
+    @Operation(summary = "디자인-이벤트 일괄 매핑", description = "특정 디자인이 속한 이벤트들을 재설정합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> updateDesignMappings(
+            @RequestBody UpdateDesignMappingRequest request
+    ) {
+        eventDesignService.updateDesignEventMappings(request);
+        return ResponseEntity.status(HttpStatus.OK).body(EMPTY_RESPONSE);
+    }
+
+    @PutMapping("/store/mapping")
+    @Operation(summary = "스토어-이벤트 일괄 매핑", description = "특정 스토어가 속한 이벤트들을 재설정합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> updateStoreMappings(
+            @RequestBody UpdateStoreMappingRequest request
+    ) {
+        eventStoreService.updateStoreEventMappings(request);
+        return ResponseEntity.status(HttpStatus.OK).body(EMPTY_RESPONSE);
+    }
+
+    @DeleteMapping("/{eventId}/designs/{designId}")
+    @Operation(summary = "이벤트 내 디자인 제거", description = "이벤트에서 특정 디자인을 제거합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> removeDesignFromEvent(
+            @PathVariable Long eventId,
+            @PathVariable Long designId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        eventDesignService.removeDesignFromEvent(eventId, designId, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(EMPTY_RESPONSE);
+    }
+
+    @DeleteMapping("/{eventId}/stores/{storeId}")
+    @Operation(summary = "이벤트 내 스토어 제거", description = "이벤트에서 특정 스토어를 제거합니다.")
+    public ResponseEntity<ResponseTemplate<Object>> removeStoreFromEvent(
+            @PathVariable Long eventId,
+            @PathVariable Long storeId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        eventStoreService.removeStoreFromEvent(eventId, storeId, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(EMPTY_RESPONSE);
+    }
 }

--- a/src/main/java/com/deark/be/event/domain/Event.java
+++ b/src/main/java/com/deark/be/event/domain/Event.java
@@ -1,8 +1,12 @@
 package com.deark.be.event.domain;
 
 import com.deark.be.global.domain.BaseTimeEntity;
+import com.deark.be.store.domain.BusinessHours;
 import com.deark.be.user.domain.User;
 import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,11 +36,41 @@ public class Event extends BaseTimeEntity {
     private String address;
 
     @Column(name = "event_date")
-    private LocalDateTime eventDate;
+    private LocalDate eventDate;
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EventStore> eventStoreList=new ArrayList<>();
+
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EventDesign> eventDesignList=new ArrayList<>();
 
     @Builder
-    public Event(User user, String title, String address, LocalDateTime eventDate) {
+    public Event(User user, String title, String address, LocalDate eventDate) {
         this.user = user;
+        this.title = title;
+        this.address = address;
+        this.eventDate = eventDate;
+    }
+
+    public void addEventStore(EventStore eventStore) {
+        eventStoreList.add(eventStore);
+        eventStore.assignEvent(this);
+    }
+
+    public void addEventDesign(EventDesign eventDesign) {
+        eventDesignList.add(eventDesign);
+        eventDesign.assignEvent(this);
+    }
+
+    public void removeEventDesign(EventDesign design) {
+        eventDesignList.remove(design);
+    }
+
+    public void removeEventStore(EventStore store) {
+        eventStoreList.remove(store);
+    }
+
+    public void update(String title, String address, LocalDate eventDate) {
         this.title = title;
         this.address = address;
         this.eventDate = eventDate;

--- a/src/main/java/com/deark/be/event/domain/Event.java
+++ b/src/main/java/com/deark/be/event/domain/Event.java
@@ -38,6 +38,26 @@ public class Event extends BaseTimeEntity {
     @Column(name = "event_date")
     private LocalDate eventDate;
 
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    // 현재 썸네일의 출처 (DESIGN or STORE)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "thumbnail_source")
+    private ThumbnailSource thumbnailSource; // enum 타입
+
+    // 현재 썸네일이 어떤 디자인/스토어의 ID로부터 왔는지
+    @Column(name = "thumbnail_source_id")
+    private Long thumbnailSourceId;
+
+    public boolean isThumbnailFromDesign(Long designId) {
+        return thumbnailSource == ThumbnailSource.DESIGN && thumbnailSourceId.equals(designId);
+    }
+
+    public boolean isThumbnailFromStore(Long storeId) {
+        return thumbnailSource == ThumbnailSource.STORE && thumbnailSourceId.equals(storeId);
+    }
+
     @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EventStore> eventStoreList=new ArrayList<>();
 
@@ -75,4 +95,19 @@ public class Event extends BaseTimeEntity {
         this.address = address;
         this.eventDate = eventDate;
     }
+
+    public void updateThumbnailIfAbsent(String url, ThumbnailSource source, Long sourceId) {
+        if (this.thumbnailUrl == null && url != null) {
+            this.thumbnailUrl = url;
+            this.thumbnailSource = source;
+            this.thumbnailSourceId = sourceId;
+        }
+    }
+
+    public void updateThumbnail(String url, ThumbnailSource source, Long sourceId) {
+        this.thumbnailUrl = url;
+        this.thumbnailSource = source;
+        this.thumbnailSourceId = sourceId;
+    }
+
 }

--- a/src/main/java/com/deark/be/event/domain/EventDesign.java
+++ b/src/main/java/com/deark/be/event/domain/EventDesign.java
@@ -1,6 +1,7 @@
 package com.deark.be.event.domain;
 
 import com.deark.be.design.domain.Design;
+import com.deark.be.global.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class EventDesign {
+public class EventDesign extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,9 +27,17 @@ public class EventDesign {
     @JoinColumn(name = "design_id", nullable = false)
     private Design design;
 
+    @Column(name = "memo")
+    private String memo;
+
     @Builder
-    public EventDesign(Event event, Design design) {
+    public EventDesign(Event event, Design design, String memo) {
         this.event = event;
         this.design = design;
+        this.memo = memo;
+    }
+
+    public void assignEvent(Event event) {
+        this.event = event;
     }
 }

--- a/src/main/java/com/deark/be/event/domain/EventStore.java
+++ b/src/main/java/com/deark/be/event/domain/EventStore.java
@@ -1,5 +1,6 @@
 package com.deark.be.event.domain;
 
+import com.deark.be.global.domain.BaseTimeEntity;
 import com.deark.be.store.domain.Store;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class EventStore {
+public class EventStore extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,9 +27,17 @@ public class EventStore {
     @JoinColumn(name = "store_id", nullable = false)
     private Store store;
 
+    @Column(name = "memo")
+    private String memo;
+
     @Builder
-    public EventStore(Event event, Store store) {
+    public EventStore(Event event, Store store,String memo) {
         this.event = event;
         this.store = store;
+        this.memo = memo;
+    }
+
+    public void assignEvent(Event event) {
+        this.event = event;
     }
 }

--- a/src/main/java/com/deark/be/event/domain/ThumbnailSource.java
+++ b/src/main/java/com/deark/be/event/domain/ThumbnailSource.java
@@ -1,0 +1,5 @@
+package com.deark.be.event.domain;
+
+public enum ThumbnailSource {
+    DESIGN, STORE
+}

--- a/src/main/java/com/deark/be/event/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/deark/be/event/dto/request/EventCreateRequest.java
@@ -1,0 +1,35 @@
+package com.deark.be.event.dto.request;
+
+import com.deark.be.event.domain.Event;
+import com.deark.be.user.domain.User;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record EventCreateRequest(
+        @Schema(description = "이벤트 제목", example = "친구 생일 파티")
+        @NotBlank(message = "이벤트 이름은 필수입니다.")
+        String title,
+
+        @Schema(description = "이벤트 날짜", example = "2025-12-25")
+        @NotNull(message = "이벤트 날짜는 필수입니다.")
+        LocalDate eventDate,
+
+        @Schema(description = "이벤트 장소", example = "서울시 강남구")
+        @NotBlank(message = "이벤트 장소는 필수입니다.")
+        String address
+) {
+    public Event toEntity(User user) {
+        return Event.builder()
+                .user(user)
+                .title(title)
+                .address(address)
+                .eventDate(eventDate)
+                .build();
+    }
+}

--- a/src/main/java/com/deark/be/event/dto/request/EventRequest.java
+++ b/src/main/java/com/deark/be/event/dto/request/EventRequest.java
@@ -1,4 +1,0 @@
-package com.deark.be.event.dto.request;
-
-public record EventRequest() {
-}

--- a/src/main/java/com/deark/be/event/dto/request/EventUpdateRequest.java
+++ b/src/main/java/com/deark/be/event/dto/request/EventUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.deark.be.event.dto.request;
+
+import com.deark.be.event.domain.Event;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record EventUpdateRequest(
+        @Schema(description = "수정할 이벤트 제목", example = "송년회 모임")
+        @NotBlank(message = "이벤트 이름은 필수입니다.")
+        String title,
+
+        @Schema(description = "수정할 이벤트 날짜", example = "2025-12-31")
+        @NotNull(message = "이벤트 날짜는 필수입니다.")
+        LocalDate eventDate,
+
+        @Schema(description = "수정할 이벤트 장소", example = "부산 해운대")
+        @NotBlank(message = "이벤트 장소는 필수입니다.")
+        String address
+) {
+    public void updateEvent(Event event) {
+        event.update(this.title, this.address,this.eventDate);
+    }
+}

--- a/src/main/java/com/deark/be/event/dto/request/UpdateDesignMappingRequest.java
+++ b/src/main/java/com/deark/be/event/dto/request/UpdateDesignMappingRequest.java
@@ -1,0 +1,15 @@
+package com.deark.be.event.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UpdateDesignMappingRequest(
+        @Schema(description = "디자인 ID", example = "1")
+        Long designId,
+        @Schema(description = "디자인을 매핑할 이벤트 ID 목록", example = "[1, 2, 3]")
+        List<Long> eventIds
+) {
+}

--- a/src/main/java/com/deark/be/event/dto/request/UpdateStoreMappingRequest.java
+++ b/src/main/java/com/deark/be/event/dto/request/UpdateStoreMappingRequest.java
@@ -1,0 +1,15 @@
+package com.deark.be.event.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record UpdateStoreMappingRequest(
+        @Schema(description = "스토어 ID", example = "55")
+        Long storeId,
+        @Schema(description = "스토어를 매핑할 이벤트 ID 목록", example = "[2, 4, 5]")
+        List<Long> eventIds
+) {
+}

--- a/src/main/java/com/deark/be/event/dto/response/DesignInEventResponse.java
+++ b/src/main/java/com/deark/be/event/dto/response/DesignInEventResponse.java
@@ -1,0 +1,31 @@
+package com.deark.be.event.dto.response;
+
+import com.deark.be.design.domain.Design;
+import com.deark.be.event.domain.EventDesign;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record DesignInEventResponse(
+        @Schema(description = "디자인 ID", example = "1")
+        Long designId,
+        @Schema(description = "디자인을 업로드한 스토어 이름", example = "케이크하우스")
+        String storeName,
+        @Schema(description = "디자인 이름", example = "생일 케이크 3단")
+        String designName,
+        @Schema(description = "디자인 이미지 URL", example = "https://cdn.deark.com/designs/3tier.png")
+        String designImageUrl,
+        @Schema(description = "해당 디자인에 대한 메모", example = "예쁘게 장식해 주세요")
+        String memo
+) {
+    public static DesignInEventResponse from(EventDesign eventDesign) {
+        Design design = eventDesign.getDesign();
+    return DesignInEventResponse.builder()
+            .designId(design.getId())
+            .storeName(design.getStore().getName())
+            .designName(design.getName())
+            .designImageUrl(design.getImageUrl())
+            .memo(eventDesign.getMemo())
+            .build();
+    }
+}

--- a/src/main/java/com/deark/be/event/dto/response/DesignInEventResponse.java
+++ b/src/main/java/com/deark/be/event/dto/response/DesignInEventResponse.java
@@ -18,8 +18,7 @@ public record DesignInEventResponse(
         @Schema(description = "해당 디자인에 대한 메모", example = "예쁘게 장식해 주세요")
         String memo
 ) {
-    public static DesignInEventResponse from(EventDesign eventDesign) {
-        Design design = eventDesign.getDesign();
+    public static DesignInEventResponse from(EventDesign eventDesign, Design design) {
     return DesignInEventResponse.builder()
             .designId(design.getId())
             .storeName(design.getStore().getName())

--- a/src/main/java/com/deark/be/event/dto/response/EventResponse.java
+++ b/src/main/java/com/deark/be/event/dto/response/EventResponse.java
@@ -18,13 +18,13 @@ public record EventResponse(
         @Schema(description = "대표 썸네일 이미지 URL", example = "https://cdn.deark.com/thumbnails/event_1.png")
         String thumbnailUrl
 ) {
-    public static EventResponse from(Event event, String thumbnailUrl) {
+    public static EventResponse of(Event event) {
         return EventResponse.builder()
                 .eventId(event.getId())
                 .title(event.getTitle())
                 .address(event.getAddress())
                 .eventDate(event.getEventDate())
-                .thumbnailUrl(thumbnailUrl)
+                .thumbnailUrl(event.getThumbnailUrl())
                 .build();
     }
 }

--- a/src/main/java/com/deark/be/event/dto/response/EventWithCheckResponse.java
+++ b/src/main/java/com/deark/be/event/dto/response/EventWithCheckResponse.java
@@ -18,16 +18,16 @@ public record EventWithCheckResponse(
         @Schema(description = "대표 썸네일 이미지 URL", example = "https://cdn.deark.com/thumbnails/event_1.png")
         String thumbnailUrl,
         @Schema(description = "해당 디자인 또는 스토어가 포함되어 있는지 여부", example = "true")
-        boolean checked
+        boolean isChecked
 ) {
-    public static EventWithCheckResponse from(Event event, String thumbnailUrl, boolean checked) {
+    public static EventWithCheckResponse of(Event event, boolean isChecked) {
         return EventWithCheckResponse.builder()
                 .eventId(event.getId())
                 .title(event.getTitle())
                 .address(event.getAddress())
                 .eventDate(event.getEventDate())
-                .thumbnailUrl(thumbnailUrl)
-                .checked(checked)
+                .thumbnailUrl(event.getThumbnailUrl())
+                .isChecked(isChecked)
                 .build();
     }
 }

--- a/src/main/java/com/deark/be/event/dto/response/EventWithCheckResponse.java
+++ b/src/main/java/com/deark/be/event/dto/response/EventWithCheckResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
-public record EventResponse(
+public record EventWithCheckResponse(
         @Schema(description = "이벤트 ID", example = "1")
         Long eventId,
         @Schema(description = "이벤트 제목", example = "생일 파티")
@@ -16,15 +16,18 @@ public record EventResponse(
         @Schema(description = "이벤트 날짜", example = "2025-06-01")
         LocalDate eventDate,
         @Schema(description = "대표 썸네일 이미지 URL", example = "https://cdn.deark.com/thumbnails/event_1.png")
-        String thumbnailUrl
+        String thumbnailUrl,
+        @Schema(description = "해당 디자인 또는 스토어가 포함되어 있는지 여부", example = "true")
+        boolean checked
 ) {
-    public static EventResponse from(Event event, String thumbnailUrl) {
-        return EventResponse.builder()
+    public static EventWithCheckResponse from(Event event, String thumbnailUrl, boolean checked) {
+        return EventWithCheckResponse.builder()
                 .eventId(event.getId())
                 .title(event.getTitle())
                 .address(event.getAddress())
                 .eventDate(event.getEventDate())
                 .thumbnailUrl(thumbnailUrl)
+                .checked(checked)
                 .build();
     }
 }

--- a/src/main/java/com/deark/be/event/dto/response/StoreInEventResponse.java
+++ b/src/main/java/com/deark/be/event/dto/response/StoreInEventResponse.java
@@ -1,0 +1,31 @@
+package com.deark.be.event.dto.response;
+
+import com.deark.be.event.domain.EventStore;
+import com.deark.be.store.domain.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record StoreInEventResponse(
+        @Schema(description = "스토어 ID", example = "10")
+        Long storeId,
+        @Schema(description = "스토어 이름", example = "달콤한 케이크점")
+        String storeName,
+        @Schema(description = "스토어 대표 이미지 URL", example = "https://cdn.deark.com/stores/store10.png")
+        String storeImageUrl,
+        @Schema(description = "스토어 주소", example = "서울특별시 마포구 양화로 45")
+        String storeAddress,
+        @Schema(description = "해당 스토어에 대한 메모", example = "추천받은 가게")
+        String memo
+) {
+    public static StoreInEventResponse from(EventStore eventStore) {
+        Store store=eventStore.getStore();
+        return StoreInEventResponse.builder()
+                .storeId(store.getId())
+                .storeName(store.getName())
+                .storeImageUrl(store.getImageUrl())
+                .storeAddress(store.getAddress())
+                .memo(eventStore.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/deark/be/event/dto/response/StoreInEventResponse.java
+++ b/src/main/java/com/deark/be/event/dto/response/StoreInEventResponse.java
@@ -18,8 +18,7 @@ public record StoreInEventResponse(
         @Schema(description = "해당 스토어에 대한 메모", example = "추천받은 가게")
         String memo
 ) {
-    public static StoreInEventResponse from(EventStore eventStore) {
-        Store store=eventStore.getStore();
+    public static StoreInEventResponse from(EventStore eventStore,Store store) {
         return StoreInEventResponse.builder()
                 .storeId(store.getId())
                 .storeName(store.getName())

--- a/src/main/java/com/deark/be/event/exception/errorcode/EventDesignErrorCode.java
+++ b/src/main/java/com/deark/be/event/exception/errorcode/EventDesignErrorCode.java
@@ -1,4 +1,4 @@
-package com.deark.be.design.exception.errorcode;
+package com.deark.be.event.exception.errorcode;
 
 import com.deark.be.global.exception.errorcode.ErrorCode;
 import lombok.Getter;
@@ -7,9 +7,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum DesignErrorCode implements ErrorCode {
-
-    DESIGN_NOT_FOUND(HttpStatus.NOT_FOUND, "DESIGN400", "케이크 디자인을 찾을 수 없습니다."),
+public enum EventDesignErrorCode implements ErrorCode {
+    EVENT_DESIGN_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_DESIGN_400", "이벤트에서 해당 디자인을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/deark/be/event/exception/errorcode/EventErrorCode.java
+++ b/src/main/java/com/deark/be/event/exception/errorcode/EventErrorCode.java
@@ -1,14 +1,17 @@
 package com.deark.be.event.exception.errorcode;
 
+import com.deark.be.global.exception.errorcode.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum EventErrorCode {
+public enum EventErrorCode implements ErrorCode {
 
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT400", "내 이벤트를 찾을 수 없습니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, "EVENT403", "이벤트에 대한 권한이 없습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/deark/be/event/exception/errorcode/EventStoreErrorCode.java
+++ b/src/main/java/com/deark/be/event/exception/errorcode/EventStoreErrorCode.java
@@ -1,4 +1,4 @@
-package com.deark.be.design.exception.errorcode;
+package com.deark.be.event.exception.errorcode;
 
 import com.deark.be.global.exception.errorcode.ErrorCode;
 import lombok.Getter;
@@ -7,9 +7,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum DesignErrorCode implements ErrorCode {
-
-    DESIGN_NOT_FOUND(HttpStatus.NOT_FOUND, "DESIGN400", "케이크 디자인을 찾을 수 없습니다."),
+public enum EventStoreErrorCode implements ErrorCode {
+    EVENT_STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVENT_STORE_400", "이벤트에서 해당 스토어를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/deark/be/event/repository/EventDesignRepository.java
+++ b/src/main/java/com/deark/be/event/repository/EventDesignRepository.java
@@ -1,0 +1,16 @@
+package com.deark.be.event.repository;
+
+import com.deark.be.design.domain.Design;
+import com.deark.be.event.domain.EventDesign;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventDesignRepository  extends JpaRepository<EventDesign,Long> {
+    Optional<EventDesign> findTopByEventIdOrderByCreatedAtAsc(Long eventId);
+    Optional<EventDesign> findByEventIdAndDesignId(Long eventId, Long designId);
+    List<EventDesign> findAllByDesign(Design design);
+    boolean existsByEventIdAndDesignId(Long eventId, Long designId);
+}

--- a/src/main/java/com/deark/be/event/repository/EventRepository.java
+++ b/src/main/java/com/deark/be/event/repository/EventRepository.java
@@ -1,9 +1,11 @@
 package com.deark.be.event.repository;
 
 import com.deark.be.event.domain.Event;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+    List<Event> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/deark/be/event/repository/EventStoreRepository.java
+++ b/src/main/java/com/deark/be/event/repository/EventStoreRepository.java
@@ -1,0 +1,16 @@
+package com.deark.be.event.repository;
+
+import com.deark.be.event.domain.EventStore;
+import com.deark.be.store.domain.Store;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EventStoreRepository extends JpaRepository<EventStore,Long> {
+    boolean existsByEventIdAndStoreId(Long eventId, Long storeId);
+    Optional<EventStore> findTopByEventIdOrderByCreatedAtAsc(Long eventId);
+    Optional<EventStore> findByEventIdAndStoreId(Long eventId, Long storeId);;
+    List<EventStore> findAllByStore(Store store);
+}

--- a/src/main/java/com/deark/be/event/repository/init/EventInitializer.java
+++ b/src/main/java/com/deark/be/event/repository/init/EventInitializer.java
@@ -1,0 +1,61 @@
+package com.deark.be.event.repository.init;
+
+import com.deark.be.event.domain.Event;
+import com.deark.be.event.repository.EventRepository;
+import com.deark.be.global.util.DummyDataInit;
+import com.deark.be.user.domain.User;
+import com.deark.be.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(4)
+@DummyDataInit
+public class EventInitializer implements ApplicationRunner {
+
+    private final EventRepository eventRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (eventRepository.count() > 0) {
+            log.info("[Event] 더미 데이터 존재");
+            return;
+        }
+
+        User user = userRepository.findById(1L).orElseThrow(); // DUMMY_USER1
+
+        Event DUMMY_EVENT0 = Event.builder()
+                .user(user)
+                .title("남자친구 생일")
+                .address("서울특별시 송파구 백제고분로 123")
+                .eventDate(LocalDate.now().plusDays(3))
+                .build();
+
+        Event DUMMY_EVENT1 = Event.builder()
+                .user(user)
+                .title("친구 결혼 축하")
+                .address("서울특별시 강남구 논현로 508")
+                .eventDate(LocalDate.now().plusWeeks(2))
+                .build();
+
+        Event DUMMY_EVENT2 = Event.builder()
+                .user(user)
+                .title("전역 축하")
+                .address("서울특별시 중랑구 망우로 300")
+                .eventDate(LocalDate.now().plusMonths(1))
+                .build();
+
+        eventRepository.saveAll(List.of(DUMMY_EVENT0, DUMMY_EVENT1, DUMMY_EVENT2));
+
+        log.info("[Event] DUMMY_USER1용 이벤트 3개 생성 완료");
+    }
+}

--- a/src/main/java/com/deark/be/event/service/EventDesignService.java
+++ b/src/main/java/com/deark/be/event/service/EventDesignService.java
@@ -1,0 +1,75 @@
+package com.deark.be.event.service;
+
+import static com.deark.be.design.exception.errorcode.DesignErrorCode.DESIGN_NOT_FOUND;
+import static com.deark.be.event.exception.errorcode.EventDesignErrorCode.EVENT_DESIGN_NOT_FOUND;
+import static com.deark.be.event.exception.errorcode.EventErrorCode.EVENT_NOT_FOUND;
+import static com.deark.be.event.exception.errorcode.EventErrorCode.NO_PERMISSION;
+
+import com.deark.be.design.domain.Design;
+import com.deark.be.design.exception.DesignException;
+import com.deark.be.design.repository.DesignRepository;
+import com.deark.be.event.domain.Event;
+import com.deark.be.event.domain.EventDesign;
+import com.deark.be.event.dto.request.UpdateDesignMappingRequest;
+import com.deark.be.event.exception.EventException;
+import com.deark.be.event.repository.EventDesignRepository;
+import com.deark.be.event.repository.EventRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventDesignService {
+    private final EventDesignRepository eventDesignRepository;
+    private final EventRepository eventRepository;
+    private final DesignRepository designRepository;
+
+    @Transactional
+    public void updateDesignEventMappings(UpdateDesignMappingRequest request) {
+        Design design = designRepository.findById(request.designId())
+                .orElseThrow(() -> new DesignException(DESIGN_NOT_FOUND));
+
+        // 1. 기존 매핑 삭제
+        List<EventDesign> existingMappings = eventDesignRepository.findAllByDesign(design);
+        for (EventDesign mapping : existingMappings) {
+            Event event = mapping.getEvent();
+            event.removeEventDesign(mapping);
+        }
+
+        // 2. 새로운 매핑 추가
+        for (Long eventId : request.eventIds()) {
+            Event event = eventRepository.findById(eventId)
+                    .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
+
+            EventDesign newMapping = EventDesign.builder()
+                    .design(design)
+                    .event(event)
+                    .build();
+
+            event.addEventDesign(newMapping);
+            eventDesignRepository.save(newMapping);
+        }
+    }
+
+    @Transactional
+    public void removeDesignFromEvent(Long eventId, Long designId, Long userId) {
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
+
+        // 소유자 확인
+        if (!event.getUser().getId().equals(userId)) {
+            throw new EventException(NO_PERMISSION);
+        }
+
+        EventDesign eventDesign = eventDesignRepository.findByEventIdAndDesignId(eventId, designId)
+                .orElseThrow(() -> new EventException(EVENT_DESIGN_NOT_FOUND));
+
+        event.getEventDesignList().remove(eventDesign);
+    }
+}

--- a/src/main/java/com/deark/be/event/service/EventDesignService.java
+++ b/src/main/java/com/deark/be/event/service/EventDesignService.java
@@ -10,11 +10,15 @@ import com.deark.be.design.exception.DesignException;
 import com.deark.be.design.repository.DesignRepository;
 import com.deark.be.event.domain.Event;
 import com.deark.be.event.domain.EventDesign;
+import com.deark.be.event.domain.ThumbnailSource;
 import com.deark.be.event.dto.request.UpdateDesignMappingRequest;
 import com.deark.be.event.exception.EventException;
 import com.deark.be.event.repository.EventDesignRepository;
 import com.deark.be.event.repository.EventRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,23 +32,63 @@ public class EventDesignService {
     private final EventDesignRepository eventDesignRepository;
     private final EventRepository eventRepository;
     private final DesignRepository designRepository;
+    private final EventService eventService;
+
 
     @Transactional
-    public void updateDesignEventMappings(UpdateDesignMappingRequest request) {
-        Design design = designRepository.findById(request.designId())
-                .orElseThrow(() -> new DesignException(DESIGN_NOT_FOUND));
+    public void updateDesignEventMappings(UpdateDesignMappingRequest request, Long userId) {
+        Design design = getDesignOrThrow(request.designId());
+        List<EventDesign> currentMappings = getUserOwnedDesignMappings(design, userId);
 
-        // 1. 기존 매핑 삭제
-        List<EventDesign> existingMappings = eventDesignRepository.findAllByDesign(design);
+        Set<Long> currentEventIds = currentMappings.stream()
+                .map(ed -> ed.getEvent().getId())
+                .collect(Collectors.toSet());
+        Set<Long> requestedEventIds = new HashSet<>(request.eventIds());
+
+        removeObsoleteDesignMappings(currentMappings, requestedEventIds, design);
+        addNewDesignMappings(requestedEventIds, currentEventIds, design, userId);
+    }
+
+
+
+    private Design getDesignOrThrow(Long designId) {
+        return designRepository.findById(designId)
+                .orElseThrow(() -> new DesignException(DESIGN_NOT_FOUND));
+    }
+
+    // 현재 로그인한 사용자가 소유한 해당 디자인의 EventDesign 매핑 목록을 가져옴
+    private List<EventDesign> getUserOwnedDesignMappings(Design design, Long userId) {
+        return eventDesignRepository.findAllByDesign(design).stream()
+                .filter(ed -> ed.getEvent().getUser().getId().equals(userId))
+                .toList();
+    }
+
+    // 기존 매핑 중 요청된 이벤트에 포함되지 않은 매핑들을 제거하고 썸네일도 필요한 경우 갱신
+    private void removeObsoleteDesignMappings(List<EventDesign> existingMappings, Set<Long> requestedEventIds, Design design) {
         for (EventDesign mapping : existingMappings) {
             Event event = mapping.getEvent();
-            event.removeEventDesign(mapping);
+            Long eventId = event.getId();
+            if (!requestedEventIds.contains(eventId)) {
+                event.removeEventDesign(mapping);
+                if (event.isThumbnailFromDesign(design.getId())) {
+                    eventService.resolveAndUpdateThumbnail(event);
+                }
+            }
         }
+    }
 
-        // 2. 새로운 매핑 추가
-        for (Long eventId : request.eventIds()) {
+    // 요청된 이벤트 중 현재 매핑이 없는 이벤트에 대해 새 매핑을 추가하고 썸네일도 최초 설정
+    private void addNewDesignMappings(Set<Long> requestedEventIds, Set<Long> currentEventIds, Design design, Long userId) {
+        Set<Long> toAdd = new HashSet<>(requestedEventIds);
+        toAdd.removeAll(currentEventIds);
+
+        for (Long eventId : toAdd) {
             Event event = eventRepository.findById(eventId)
                     .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
+
+            if (!event.getUser().getId().equals(userId)) {
+                throw new EventException(NO_PERMISSION);
+            }
 
             EventDesign newMapping = EventDesign.builder()
                     .design(design)
@@ -53,23 +97,24 @@ public class EventDesignService {
 
             event.addEventDesign(newMapping);
             eventDesignRepository.save(newMapping);
+            event.updateThumbnailIfAbsent(design.getImageUrl(), ThumbnailSource.DESIGN, design.getId());
         }
     }
 
     @Transactional
     public void removeDesignFromEvent(Long eventId, Long designId, Long userId) {
 
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
-
-        // 소유자 확인
-        if (!event.getUser().getId().equals(userId)) {
-            throw new EventException(NO_PERMISSION);
-        }
+        Event event=eventService.getValidatedEvent(eventId,userId);
 
         EventDesign eventDesign = eventDesignRepository.findByEventIdAndDesignId(eventId, designId)
                 .orElseThrow(() -> new EventException(EVENT_DESIGN_NOT_FOUND));
 
         event.getEventDesignList().remove(eventDesign);
+
+        // 썸네일이 해당 디자인에서 왔다면 갱신 필요
+        if (event.isThumbnailFromDesign(designId)) {
+            eventService.resolveAndUpdateThumbnail(event);
+        }
     }
+
 }

--- a/src/main/java/com/deark/be/event/service/EventService.java
+++ b/src/main/java/com/deark/be/event/service/EventService.java
@@ -1,5 +1,28 @@
 package com.deark.be.event.service;
 
+import static com.deark.be.event.exception.errorcode.EventErrorCode.EVENT_NOT_FOUND;
+import static com.deark.be.event.exception.errorcode.EventErrorCode.NO_PERMISSION;
+import static com.deark.be.user.exception.errorcode.UserErrorCode.USER_NOT_FOUND;
+
+import com.deark.be.event.domain.Event;
+import com.deark.be.event.domain.EventDesign;
+import com.deark.be.event.domain.EventStore;
+import com.deark.be.event.dto.request.EventCreateRequest;
+import com.deark.be.event.dto.request.EventUpdateRequest;
+import com.deark.be.event.dto.response.DesignInEventResponse;
+import com.deark.be.event.dto.response.EventResponse;
+import com.deark.be.event.dto.response.EventWithCheckResponse;
+import com.deark.be.event.dto.response.StoreInEventResponse;
+import com.deark.be.event.exception.EventException;
+import com.deark.be.event.repository.EventDesignRepository;
+import com.deark.be.event.repository.EventRepository;
+import com.deark.be.event.repository.EventStoreRepository;
+import com.deark.be.user.domain.User;
+import com.deark.be.user.exception.UserException;
+import com.deark.be.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,4 +33,134 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class EventService {
+    private final EventRepository eventRepository;
+    private final UserRepository userRepository;
+    private final EventDesignRepository eventDesignRepository;
+    private final EventStoreRepository eventStoreRepository;
+
+    public List<EventResponse> getMyEvents(Long userId) {
+        User user=getValidatedUser(userId);
+        List<Event> events = user.getEventList();
+        return events.stream()
+                .map(event ->{
+                    String thumnailUrl=resolveThumbnail(event);
+                    return EventResponse.from(event, thumnailUrl);
+                })
+                .collect(Collectors.toList());
+    }
+
+    public EventResponse getEventDetail(Long eventId, Long userId) {
+        Event event = getValidatedEvent(eventId,userId);
+        return EventResponse.from(event,resolveThumbnail(event));
+    }
+
+    @Transactional
+    public Long createEvent(Long userId,EventCreateRequest request) {
+        User user=getValidatedUser(userId);
+        Event event=request.toEntity(user);
+        return eventRepository.save(event).getId();
+    }
+
+    @Transactional
+    public void deleteEvent(Long eventId, Long userId) {
+        Event event = getValidatedEvent(eventId,userId);
+        eventRepository.delete(event);
+    }
+
+    @Transactional
+    public void updateEvent(Long eventId, Long userId, EventUpdateRequest request) {
+        Event event = getValidatedEvent(eventId,userId);
+        request.updateEvent(event);
+    }
+
+    public List<DesignInEventResponse> getDesignsInEvent(Long eventId, Long userId) {
+        Event event = getValidatedEvent(eventId, userId);
+
+        return event.getEventDesignList().stream()
+                .map(DesignInEventResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<StoreInEventResponse> getStoresInEvent(Long eventId, Long userId) {
+        Event event = getValidatedEvent(eventId, userId);
+
+        return event.getEventStoreList().stream()
+                .map(StoreInEventResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public String resolveThumbnail(Event event) {
+        Optional<EventDesign> firstDesignOpt = eventDesignRepository
+                .findTopByEventIdOrderByCreatedAtAsc(event.getId());
+
+        Optional<EventStore> firstStoreOpt = eventStoreRepository
+                .findTopByEventIdOrderByCreatedAtAsc(event.getId());
+
+        // 둘 다 존재하면 비교
+        if (firstDesignOpt.isPresent() && firstStoreOpt.isPresent()) {
+            EventDesign design = firstDesignOpt.get();
+            EventStore store = firstStoreOpt.get();
+
+            return design.getCreatedAt().isBefore(store.getCreatedAt())
+                    ? design.getDesign().getImageUrl()
+                    : store.getStore().getImageUrl();
+        }
+
+        // 하나만 존재하는 경우
+        if (firstDesignOpt.isPresent()) {
+            return firstDesignOpt.get().getDesign().getImageUrl();
+        }
+
+        if (firstStoreOpt.isPresent()) {
+            return firstStoreOpt.get().getStore().getImageUrl();
+        }
+
+        // 아무것도 없으면 기본 이미지 또는 null
+        return null;
+    }
+
+
+
+    public List<EventWithCheckResponse> getMyEventsWithCheckForDesign(Long userId, Long designId) {
+        User user=getValidatedUser(userId);
+
+        List<Event> events = user.getEventList();
+
+        return events.stream()
+                .map(event -> {
+                    boolean isChecked = eventDesignRepository.existsByEventIdAndDesignId(event.getId(), designId);
+                    String thumbnailUrl = resolveThumbnail(event);
+                    return EventWithCheckResponse.from(event, thumbnailUrl, isChecked);
+                })
+                .collect(Collectors.toList());
+    }
+
+    public List<EventWithCheckResponse> getMyEventsWithCheckForStore(Long userId, Long storeId) {
+        User user=getValidatedUser(userId);
+        List<Event> events = user.getEventList();
+
+        return events.stream()
+                .map(event -> {
+                    boolean isChecked = eventStoreRepository.existsByEventIdAndStoreId(event.getId(), storeId);
+                    String thumbnailUrl = resolveThumbnail(event);
+                    return EventWithCheckResponse.from(event, thumbnailUrl, isChecked);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private Event getValidatedEvent(Long eventId, Long userId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
+
+        if (!event.getUser().getId().equals(userId)) {
+            throw new EventException(NO_PERMISSION);
+        }
+
+        return event;
+    }
+
+    private User getValidatedUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/deark/be/event/service/EventStoreService.java
+++ b/src/main/java/com/deark/be/event/service/EventStoreService.java
@@ -1,6 +1,5 @@
 package com.deark.be.event.service;
 
-import static com.deark.be.event.exception.errorcode.EventDesignErrorCode.EVENT_DESIGN_NOT_FOUND;
 import static com.deark.be.event.exception.errorcode.EventErrorCode.EVENT_NOT_FOUND;
 import static com.deark.be.event.exception.errorcode.EventErrorCode.NO_PERMISSION;
 import static com.deark.be.event.exception.errorcode.EventStoreErrorCode.EVENT_STORE_NOT_FOUND;
@@ -8,6 +7,7 @@ import static com.deark.be.store.exception.errorcode.StoreErrorCode.STORE_NOT_FO
 
 import com.deark.be.event.domain.Event;
 import com.deark.be.event.domain.EventStore;
+import com.deark.be.event.domain.ThumbnailSource;
 import com.deark.be.event.dto.request.UpdateStoreMappingRequest;
 import com.deark.be.event.exception.EventException;
 import com.deark.be.event.repository.EventRepository;
@@ -15,7 +15,10 @@ import com.deark.be.event.repository.EventStoreRepository;
 import com.deark.be.store.domain.Store;
 import com.deark.be.store.exception.StoreException;
 import com.deark.be.store.repository.StoreRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,24 +32,62 @@ public class EventStoreService {
     private final EventStoreRepository eventStoreRepository;
     private final EventRepository eventRepository;
     private final StoreRepository storeRepository;
-
+    private final EventService eventService;
 
     @Transactional
-    public void updateStoreEventMappings(UpdateStoreMappingRequest request) {
-        Store store = storeRepository.findById(request.storeId())
-                .orElseThrow(() -> new StoreException(STORE_NOT_FOUND));
+    public void updateStoreEventMappings(UpdateStoreMappingRequest request, Long userId) {
+        Store store = getStoreOrThrow(request.storeId());
+        List<EventStore> currentMappings = getUserOwnedStoreMappings(store, userId);
 
-        // 1. 기존 매핑 삭제
-        List<EventStore> existingMappings = eventStoreRepository.findAllByStore(store);
+        Set<Long> currentEventIds = currentMappings.stream()
+                .map(ed -> ed.getEvent().getId())
+                .collect(Collectors.toSet());
+        Set<Long> requestedEventIds = new HashSet<>(request.eventIds());
+
+        removeObsoleteStoreMappings(currentMappings, requestedEventIds, store);
+        addNewStoreMappings(requestedEventIds, currentEventIds, store, userId);
+    }
+
+    private Store getStoreOrThrow(Long storeId) {
+        return storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(STORE_NOT_FOUND));
+    }
+
+    // 현재 로그인한 사용자가 소유한 해당 스토어의 EventStore 매핑 목록을 가져옴
+    private List<EventStore> getUserOwnedStoreMappings(Store store, Long userId) {
+        return eventStoreRepository.findAllByStore(store).stream()
+                .filter(es -> es.getEvent().getUser().getId().equals(userId))
+                .toList();
+    }
+
+    // 기존 매핑 중 요청된 이벤트에 포함되지 않은 매핑들을 제거하고 썸네일도 필요한 경우 갱신
+    private void removeObsoleteStoreMappings(List<EventStore> existingMappings, Set<Long> requestedEventIds, Store store) {
         for (EventStore mapping : existingMappings) {
             Event event = mapping.getEvent();
-            event.removeEventStore(mapping);
-        }
+            Long eventId = event.getId();
 
-        // 2. 새로운 매핑 추가
-        for (Long eventId : request.eventIds()) {
+            if (!requestedEventIds.contains(eventId)) {
+                event.removeEventStore(mapping);
+
+                if (event.isThumbnailFromStore(store.getId())) {
+                    eventService.resolveAndUpdateThumbnail(event);
+                }
+            }
+        }
+    }
+
+    // 요청된 이벤트 중 현재 매핑이 없는 이벤트에 대해 새 매핑을 추가하고 썸네일도 최초 설정
+    private void addNewStoreMappings(Set<Long> requestedEventIds, Set<Long> currentEventIds, Store store, Long userId) {
+        Set<Long> toAdd = new HashSet<>(requestedEventIds);
+        toAdd.removeAll(currentEventIds);
+
+        for (Long eventId : toAdd) {
             Event event = eventRepository.findById(eventId)
                     .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
+
+            if (!event.getUser().getId().equals(userId)) {
+                throw new EventException(NO_PERMISSION);
+            }
 
             EventStore newMapping = EventStore.builder()
                     .store(store)
@@ -55,22 +96,25 @@ public class EventStoreService {
 
             event.addEventStore(newMapping);
             eventStoreRepository.save(newMapping);
+
+            // 썸네일이 비어있으면 설정
+            event.updateThumbnailIfAbsent(store.getImageUrl(), ThumbnailSource.STORE, store.getId());
         }
     }
 
     @Transactional
     public void removeStoreFromEvent(Long eventId, Long storeId, Long userId) {
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
-
-        // 소유자 확인
-        if (!event.getUser().getId().equals(userId)) {
-            throw new EventException(NO_PERMISSION);
-        }
+        Event event=eventService.getValidatedEvent(eventId,userId);
 
         EventStore eventStore = eventStoreRepository.findByEventIdAndStoreId(eventId, storeId)
                 .orElseThrow(() -> new EventException(EVENT_STORE_NOT_FOUND));
 
         event.getEventStoreList().remove(eventStore);
+
+        // 썸네일이 해당 스토어에서 왔다면 갱신 필요
+        if (event.isThumbnailFromStore(storeId)) {
+            eventService.resolveAndUpdateThumbnail(event);
+        }
     }
+
 }

--- a/src/main/java/com/deark/be/event/service/EventStoreService.java
+++ b/src/main/java/com/deark/be/event/service/EventStoreService.java
@@ -1,0 +1,76 @@
+package com.deark.be.event.service;
+
+import static com.deark.be.event.exception.errorcode.EventDesignErrorCode.EVENT_DESIGN_NOT_FOUND;
+import static com.deark.be.event.exception.errorcode.EventErrorCode.EVENT_NOT_FOUND;
+import static com.deark.be.event.exception.errorcode.EventErrorCode.NO_PERMISSION;
+import static com.deark.be.event.exception.errorcode.EventStoreErrorCode.EVENT_STORE_NOT_FOUND;
+import static com.deark.be.store.exception.errorcode.StoreErrorCode.STORE_NOT_FOUND;
+
+import com.deark.be.event.domain.Event;
+import com.deark.be.event.domain.EventStore;
+import com.deark.be.event.dto.request.UpdateStoreMappingRequest;
+import com.deark.be.event.exception.EventException;
+import com.deark.be.event.repository.EventRepository;
+import com.deark.be.event.repository.EventStoreRepository;
+import com.deark.be.store.domain.Store;
+import com.deark.be.store.exception.StoreException;
+import com.deark.be.store.repository.StoreRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventStoreService {
+    private final EventStoreRepository eventStoreRepository;
+    private final EventRepository eventRepository;
+    private final StoreRepository storeRepository;
+
+
+    @Transactional
+    public void updateStoreEventMappings(UpdateStoreMappingRequest request) {
+        Store store = storeRepository.findById(request.storeId())
+                .orElseThrow(() -> new StoreException(STORE_NOT_FOUND));
+
+        // 1. 기존 매핑 삭제
+        List<EventStore> existingMappings = eventStoreRepository.findAllByStore(store);
+        for (EventStore mapping : existingMappings) {
+            Event event = mapping.getEvent();
+            event.removeEventStore(mapping);
+        }
+
+        // 2. 새로운 매핑 추가
+        for (Long eventId : request.eventIds()) {
+            Event event = eventRepository.findById(eventId)
+                    .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
+
+            EventStore newMapping = EventStore.builder()
+                    .store(store)
+                    .event(event)
+                    .build();
+
+            event.addEventStore(newMapping);
+            eventStoreRepository.save(newMapping);
+        }
+    }
+
+    @Transactional
+    public void removeStoreFromEvent(Long eventId, Long storeId, Long userId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventException(EVENT_NOT_FOUND));
+
+        // 소유자 확인
+        if (!event.getUser().getId().equals(userId)) {
+            throw new EventException(NO_PERMISSION);
+        }
+
+        EventStore eventStore = eventStoreRepository.findByEventIdAndStoreId(eventId, storeId)
+                .orElseThrow(() -> new EventException(EVENT_STORE_NOT_FOUND));
+
+        event.getEventStoreList().remove(eventStore);
+    }
+}

--- a/src/main/java/com/deark/be/store/controller/StoreController.java
+++ b/src/main/java/com/deark/be/store/controller/StoreController.java
@@ -48,7 +48,7 @@ public class StoreController {
                 .ok(ResponseTemplate.from(storeId));
     }
 
-    @PostMapping("/basic-info")
+    @PostMapping("/basic_info")
     @Operation(summary = "가게 기본 정보 등록", description = "입점 후, 기본정보 및 영업시간을 등록합니다.")
     public ResponseEntity<ResponseTemplate<Object>> registerStoreBasicInfo(
             @RequestParam Long storeId,

--- a/src/main/java/com/deark/be/user/domain/User.java
+++ b/src/main/java/com/deark/be/user/domain/User.java
@@ -1,9 +1,12 @@
 package com.deark.be.user.domain;
 
 import com.deark.be.auth.dto.response.OAuthInfoResponse;
+import com.deark.be.event.domain.Event;
 import com.deark.be.global.domain.BaseTimeEntity;
 import com.deark.be.user.domain.type.Role;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,6 +50,9 @@ public class User extends BaseTimeEntity {
 
     @Column(name = "profile_image_url")
     private String profileImageUrl;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Event> eventList=new ArrayList<>();
 
     @Builder
     public User(String name, String email, String phone, String socialId, Role role, Boolean isBlacklist,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #27 
## 📝작업 내용

이번 PR에서는 이벤트 기능 전반에 대한 개발을 완료하였습니다.  
사용자는 이벤트를 생성하고, 조회하고, 수정 및 삭제할 수 있으며, 해당 이벤트에 스토어 및 디자인을 연결하거나 제거할 수 있습니다.

- Event 엔티티 및 연관관계 도메인 설계 및 구현
- `EventController`를 통한 전체 이벤트 API 개발
  - 이벤트 생성, 수정, 삭제, 단일 조회, 내 이벤트 전체 조회
  - 특정 디자인/스토어가 포함된 이벤트 목록 조회
  - 이벤트 내 디자인/스토어 조회 및 매핑/삭제 기능 추가
- DTO 클래스 (Request/Response) 정의 및 Swagger 스키마 주석 작성
- 이벤트 **썸네일 로직** 구현 (가장 먼저 등록된 디자인 또는 스토어 기준)
- 관련된 Repository, Service, Exception 코드 정리 및 분리

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/8deb7d6f-7c94-4cbc-bd2e-995e60584a4e)

## 💬리뷰 요구사항(선택)
이벤트의 썸네일은 가장 먼저 찜된 디자인 또는 스토어의 이미지여야 한다는 요구사항에 맞춰  EventService의 resolveThumbnail 메소드를 구현했습니다. 하지만 Optional과 조건문이 반복되어 코드가 다소 길고 복잡해진 느낌이 있습니다.
위 로직보다 더 간결하고 가독성 좋은 방식이 있다면 제안 부탁드립니다 !




## 🔁 피드백 반영 사항

- **스토어/디자인과 이벤트의 매핑 일괄 update 로직 개선**  
  기존에는 기존 매핑을 모두 삭제하고 요청된 매핑을 새로 삽입하는 방식이었으나,  
  실제 변경된 매핑만 선별적으로 삭제 및 추가하도록 개선하여 **데이터 무결성**과 **성능**을 향상시켰습니다.

- **이벤트 엔티티에 썸네일 관련 컬럼 추가**  
  이벤트 객체가 썸네일을 직접 기억할 수 있도록  
  `thumbnailUrl`, `thumbnailSource`, `thumbnailSourceId` 필드를 도입하였습니다.

- **`EventStoreService`, `EventDesignService` 리팩토링**  
  메소드 분리 및 책임 분담을 통해 서비스 클래스의 **가독성과 유지보수성**을 높였습니다.

- **`resolveAndUpdateThumbnail()` 메소드 구현**  
  매핑된 디자인 또는 스토어가 **썸네일 출처일 경우 제거 시 자동 갱신**되도록  
  이벤트의 썸네일 정보를 가장 오래된 등록 항목으로 자동 갱신하는 로직을 구현했습니다.

- **이벤트 더미데이터 추가**
  DUMMY_USER1이 소유한 이벤트(DUMMY_EVENT0~2)를 추가하여 테스트 및 개발 환경에서의 검증이 용이하도록 하였습니다.