### PR TITLE
[FEAT] 프로필 등록 기능

### DIFF
--- a/src/main/java/com/deark/be/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/deark/be/auth/dto/response/LoginResponse.java
@@ -6,11 +6,15 @@ import lombok.Builder;
 
 @Builder
 public record LoginResponse(
-        Role role
+        Role role,
+        Long userId,
+        String profileImageUrl
 ) {
     public static LoginResponse from(User user) {
         return LoginResponse.builder()
                 .role(user.getRole())
+                .userId(user.getId())
+                .profileImageUrl(user.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/deark/be/user/controller/UserController.java
+++ b/src/main/java/com/deark/be/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.deark.be.user.controller;
 
 import com.deark.be.global.dto.ResponseTemplate;
+import com.deark.be.user.dto.request.SaveProfileRequest;
 import com.deark.be.user.dto.request.UpdateRoleRequest;
 import com.deark.be.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,9 +10,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import static com.deark.be.global.dto.ResponseTemplate.EMPTY_RESPONSE;
 
@@ -48,5 +51,19 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(response));
+    }
+
+    @Operation(summary = "프로필 등록", description = "회원가입 후 닉네임, 프로필 사진, 토큰을 등록합니다")
+    @PostMapping(value = "/profile", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<ResponseTemplate<Object>> saveProfile(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestPart SaveProfileRequest request,
+            @RequestPart(required = false) MultipartFile file) {
+
+        userService.saveProfile(userId, request, file);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(EMPTY_RESPONSE);
     }
 }

--- a/src/main/java/com/deark/be/user/controller/UserController.java
+++ b/src/main/java/com/deark/be/user/controller/UserController.java
@@ -53,7 +53,8 @@ public class UserController {
                 .body(ResponseTemplate.from(response));
     }
 
-    @Operation(summary = "프로필 등록", description = "회원가입 후 프로필 사진, 닉네임, 성별, 생년월일을 등록합니다")
+    @Operation(summary = "프로필 등록", description = "회원가입 후 프로필 사진, 닉네임, 성별, 생년월일을 등록합니다 <br>" +
+            "마케팅 수신 동의 여부는 isMarketingAgreement에, 제3자 제공 동의 여부는 isThirdPartyAgreement에 입력해주세요.")
     @PostMapping(value = "/profile", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<ResponseTemplate<Object>> saveProfile(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/deark/be/user/controller/UserController.java
+++ b/src/main/java/com/deark/be/user/controller/UserController.java
@@ -5,15 +5,13 @@ import com.deark.be.user.dto.request.UpdateRoleRequest;
 import com.deark.be.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.deark.be.global.dto.ResponseTemplate.EMPTY_RESPONSE;
 
@@ -38,5 +36,17 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(EMPTY_RESPONSE);
+    }
+
+    @Operation(summary = "닉네임 중복 검사", description = "닉네임이 존재하면 true, 존재하지 않으면 false를 반환합니다")
+    @GetMapping("/nickname/validation")
+    public ResponseEntity<ResponseTemplate<Object>> validateNickname(
+            @Valid @RequestParam String nickname) {
+
+        Boolean response = userService.validateNickname(nickname);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(response));
     }
 }

--- a/src/main/java/com/deark/be/user/controller/UserController.java
+++ b/src/main/java/com/deark/be/user/controller/UserController.java
@@ -53,7 +53,7 @@ public class UserController {
                 .body(ResponseTemplate.from(response));
     }
 
-    @Operation(summary = "프로필 등록", description = "회원가입 후 닉네임, 프로필 사진, 토큰을 등록합니다")
+    @Operation(summary = "프로필 등록", description = "회원가입 후 프로필 사진, 닉네임, 성별, 생년월일을 등록합니다")
     @PostMapping(value = "/profile", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<ResponseTemplate<Object>> saveProfile(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/deark/be/user/domain/User.java
+++ b/src/main/java/com/deark/be/user/domain/User.java
@@ -62,12 +62,19 @@ public class User extends BaseTimeEntity {
     @Column(name = "birth_date")
     private LocalDate birthDate;
 
+    @Column(name = "is_marketing_agreement")
+    private Boolean isMarketingAgreement;
+
+    @Column(name = "is_push_agreement")
+    private Boolean isThirdPartyAgreement;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Event> eventList = new ArrayList<>();
 
     @Builder
     public User(String name, String email, String phone, String socialId, Role role, Boolean isBlacklist,
-                String nickname, String profileImageUrl, Gender gender, LocalDate birthDate, List<Event> eventList) {
+                String nickname, String profileImageUrl, Gender gender, LocalDate birthDate, List<Event> eventList,
+                Boolean isMarketingAgreement, Boolean isThirdPartyAgreement) {
         this.name = name;
         this.email = email;
         this.phone = phone;
@@ -78,10 +85,12 @@ public class User extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
         this.gender = gender;
         this.birthDate = birthDate;
+        this.isMarketingAgreement = isMarketingAgreement;
+        this.isThirdPartyAgreement = isThirdPartyAgreement;
         this.eventList = eventList;
     }
 
-    public static User of(OAuthInfoResponse oAuthInfoResponse) {
+    public static User from(OAuthInfoResponse oAuthInfoResponse) {
         return User.builder()
                 .name(oAuthInfoResponse.getName())
                 .email(oAuthInfoResponse.getEmail())
@@ -102,6 +111,8 @@ public class User extends BaseTimeEntity {
         this.nickname = request.nickname();
         this.gender = request.gender();
         this.birthDate = request.birthDate();
+        this.isMarketingAgreement = request.isMarketingAgreement();
+        this.isThirdPartyAgreement = request.isThridPartyAgreement();
 
         if (!profileImageUrl.isEmpty()) {
             this.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/deark/be/user/domain/User.java
+++ b/src/main/java/com/deark/be/user/domain/User.java
@@ -3,8 +3,12 @@ package com.deark.be.user.domain;
 import com.deark.be.auth.dto.response.OAuthInfoResponse;
 import com.deark.be.event.domain.Event;
 import com.deark.be.global.domain.BaseTimeEntity;
+import com.deark.be.user.domain.type.Gender;
 import com.deark.be.user.domain.type.Role;
+import com.deark.be.user.dto.request.SaveProfileRequest;
 import jakarta.persistence.*;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -51,12 +55,19 @@ public class User extends BaseTimeEntity {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Event> eventList=new ArrayList<>();
+    private List<Event> eventList = new ArrayList<>();
 
     @Builder
     public User(String name, String email, String phone, String socialId, Role role, Boolean isBlacklist,
-                String nickname, String profileImageUrl) {
+                String nickname, String profileImageUrl, Gender gender, LocalDate birthDate, List<Event> eventList) {
         this.name = name;
         this.email = email;
         this.phone = phone;
@@ -65,6 +76,9 @@ public class User extends BaseTimeEntity {
         this.isBlacklist = isBlacklist;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.gender = gender;
+        this.birthDate = birthDate;
+        this.eventList = eventList;
     }
 
     public static User of(OAuthInfoResponse oAuthInfoResponse) {
@@ -82,6 +96,16 @@ public class User extends BaseTimeEntity {
 
     public void updateRole(Role role) {
         this.role = role;
+    }
+
+    public void saveProfile(SaveProfileRequest request, String profileImageUrl) {
+        this.nickname = request.nickname();
+        this.gender = request.gender();
+        this.birthDate = request.birthDate();
+
+        if (!profileImageUrl.isEmpty()) {
+            this.profileImageUrl = profileImageUrl;
+        }
     }
 
     private static String formatPhoneNumber(String originalPhoneNumber) {

--- a/src/main/java/com/deark/be/user/domain/type/Gender.java
+++ b/src/main/java/com/deark/be/user/domain/type/Gender.java
@@ -1,0 +1,7 @@
+package com.deark.be.user.domain.type;
+
+public enum Gender {
+    MAN,
+    WOMAN,
+    ;
+}

--- a/src/main/java/com/deark/be/user/dto/request/SaveProfileRequest.java
+++ b/src/main/java/com/deark/be/user/dto/request/SaveProfileRequest.java
@@ -1,0 +1,12 @@
+package com.deark.be.user.dto.request;
+
+import com.deark.be.user.domain.type.Gender;
+
+import java.time.LocalDate;
+
+public record SaveProfileRequest(
+        String nickname,
+        Gender gender,
+        LocalDate birthDate
+) {
+}

--- a/src/main/java/com/deark/be/user/dto/request/SaveProfileRequest.java
+++ b/src/main/java/com/deark/be/user/dto/request/SaveProfileRequest.java
@@ -7,6 +7,8 @@ import java.time.LocalDate;
 public record SaveProfileRequest(
         String nickname,
         Gender gender,
-        LocalDate birthDate
+        LocalDate birthDate,
+        Boolean isMarketingAgreement,
+        Boolean isThridPartyAgreement
 ) {
 }

--- a/src/main/java/com/deark/be/user/dto/request/UserRequest.java
+++ b/src/main/java/com/deark/be/user/dto/request/UserRequest.java
@@ -1,4 +1,0 @@
-package com.deark.be.user.dto.request;
-
-public class UserRequest {
-}

--- a/src/main/java/com/deark/be/user/dto/response/UserResponse.java
+++ b/src/main/java/com/deark/be/user/dto/response/UserResponse.java
@@ -1,4 +1,0 @@
-package com.deark.be.user.dto.response;
-
-public class UserResponse {
-}

--- a/src/main/java/com/deark/be/user/repository/UserRepository.java
+++ b/src/main/java/com/deark/be/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findBySocialId(String socialId);
+
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/deark/be/user/service/UserService.java
+++ b/src/main/java/com/deark/be/user/service/UserService.java
@@ -54,7 +54,7 @@ public class UserService {
     }
 
     private User saveUser(OAuthInfoResponse oAuthInfoResponse) {
-        return userRepository.save(User.of(oAuthInfoResponse));
+        return userRepository.save(User.from(oAuthInfoResponse));
     }
 
     private String uploadProfileImage(MultipartFile file) {

--- a/src/main/java/com/deark/be/user/service/UserService.java
+++ b/src/main/java/com/deark/be/user/service/UserService.java
@@ -32,6 +32,10 @@ public class UserService {
         user.updateRole(request.role());
     }
 
+    public Boolean validateNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
     public User findUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(USER_NOT_FOUND));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31 

## 📝작업 내용

> 카카오 로그인 시 role, userId, profileImageUrl 함께 제공
> 닉네임 중복 검사
> 프로필 등록 기능 (성별, 생년월일 등)

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b9e730de-c17b-467a-9630-635d4e8bb6f4)

## 💬리뷰 요구사항(선택)

* 프로필 등록에 성별과 생년월일도 포함되어 있어서 해당 칼럼 User 엔티티에 추가하였습니다!
* 이용약관 동의는 DB에 따로 저장해야 될까요..??
