### PR TITLE
[FEAT] 가게 상세 조회

### DIFF
--- a/src/main/java/com/deark/be/design/repository/SizeRepository.java
+++ b/src/main/java/com/deark/be/design/repository/SizeRepository.java
@@ -1,9 +1,15 @@
 package com.deark.be.design.repository;
 
 import com.deark.be.design.domain.Size;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SizeRepository extends JpaRepository<Size, Long> {
+    @Query("SELECT s.name FROM Size s WHERE s.design.store.id = :storeId")
+    List<String> findSizeNamesByStoreId(@Param("storeId") Long storeId);
+    boolean existsByStoreIdAndNameContaining(Long storeId, String keyword);
 }

--- a/src/main/java/com/deark/be/event/repository/EventStoreRepository.java
+++ b/src/main/java/com/deark/be/event/repository/EventStoreRepository.java
@@ -13,4 +13,5 @@ public interface EventStoreRepository extends JpaRepository<EventStore,Long> {
     Optional<EventStore> findTopByEventIdOrderByCreatedAtAsc(Long eventId);
     Optional<EventStore> findByEventIdAndStoreId(Long eventId, Long storeId);;
     List<EventStore> findAllByStore(Store store);
+    Long countByStoreId(Long storeId);
 }

--- a/src/main/java/com/deark/be/event/repository/EventStoreRepository.java
+++ b/src/main/java/com/deark/be/event/repository/EventStoreRepository.java
@@ -14,4 +14,5 @@ public interface EventStoreRepository extends JpaRepository<EventStore,Long> {
     Optional<EventStore> findByEventIdAndStoreId(Long eventId, Long storeId);;
     List<EventStore> findAllByStore(Store store);
     Long countByStoreId(Long storeId);
+    boolean existsByEventUserIdAndStoreId(Long userId, Long storeId);
 }

--- a/src/main/java/com/deark/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/deark/be/global/config/SecurityConfig.java
@@ -64,17 +64,4 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedMethod("*");
-        config.addAllowedHeader("*");
-        config.setAllowCredentials(true);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
-        return source;
-    }
 }

--- a/src/main/java/com/deark/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/deark/be/global/config/SecurityConfig.java
@@ -15,6 +15,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -60,5 +63,18 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOrigin("http://localhost:3000");
+        config.addAllowedMethod("*");
+        config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/src/main/java/com/deark/be/store/controller/StoreController.java
+++ b/src/main/java/com/deark/be/store/controller/StoreController.java
@@ -33,17 +33,18 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    @PostMapping(value = "/register", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    @PostMapping(value = "/register", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE})
     @Operation(summary = "가게 입점 등록", description = """
-        S3에 미리 업로드된 파일 URL을 기반으로 가게 입점 정보를 등록합니다.
-        """)
+            S3에 미리 업로드된 파일 URL을 기반으로 가게 입점 정보를 등록합니다.
+            """)
     public ResponseEntity<ResponseTemplate<Long>> registerStore(
             @RequestPart("request") @Valid StoreRegisterRequest request,
             @RequestPart("businessLicenseFile") MultipartFile businessLicenseFile,
             @RequestPart("businessPermitFile") MultipartFile businessPermitFile,
             @AuthenticationPrincipal Long userId
     ) {
-        Long storeId = storeService.registerStore(request,userId,businessLicenseFile,businessPermitFile);
+        Long storeId = storeService.registerStore(request, userId, businessLicenseFile, businessPermitFile);
         return ResponseEntity
                 .ok(ResponseTemplate.from(storeId));
     }
@@ -62,7 +63,8 @@ public class StoreController {
 
     @Operation(summary = "가게 통합 검색", description = "page는 0부터 시작합니다. hasNext가 false이면 마지막 페이지입니다.<br><br>" +
             "입력받은 값 : keyword / 당일 주문 여부 : isSameDayOrder / 지역 리스트 : locationList (ex. 강남구, 중랑구) <br>" +
-            "시작일 : '2025-01-01' 형식으로 startDate / 종료일 : '2025-01-01' 형식으로 endDate (하루만 선택할 경우 시작일과 종료일을 같게 입력해주세요.) <br>" +
+            "시작일 : '2025-01-01' 형식으로 startDate / 종료일 : '2025-01-01' 형식으로 endDate (하루만 선택할 경우 시작일과 종료일을 같게 입력해주세요.) <br>"
+            +
             "최소 금액 : minPrice / 최대 금액 : maxPrice / 도시락 케이크 여부는 isLunchBoxCake 에 입력해주세요.")
     @GetMapping("/search")
     public ResponseEntity<ResponseTemplate<SearchStoreResponseList>> searchStore(
@@ -91,10 +93,11 @@ public class StoreController {
     @Operation(summary = "스토어 상세 조회", description = "스토어 상세 정보를 조회합니다.<br>"
             + "가게에서 설정한 모든 사이즈 정보도 이때 함께 응답합니다.")
     @GetMapping("/detail/{storeId}")
-    public ResponseEntity<ResponseTemplate<Object>> getStoreDetail(
-            @PathVariable Long storeId
+    public ResponseEntity<ResponseTemplate<StoreDetailResponse>> getStoreDetail(
+            @PathVariable Long storeId,
+            @AuthenticationPrincipal Long userId
     ) {
-        StoreDetailResponse storeDetail = storeService.getstoreDetail(storeId);
+        StoreDetailResponse storeDetail = storeService.getStoreDetail(storeId, userId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(storeDetail));

--- a/src/main/java/com/deark/be/store/controller/StoreController.java
+++ b/src/main/java/com/deark/be/store/controller/StoreController.java
@@ -5,6 +5,7 @@ import com.deark.be.store.domain.type.SortType;
 import com.deark.be.store.dto.request.StoreBasicInfoRequest;
 import com.deark.be.store.dto.request.StoreRegisterRequest;
 import com.deark.be.store.dto.response.SearchStoreResponseList;
+import com.deark.be.store.dto.response.StoreDetailResponse;
 import com.deark.be.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,17 +33,18 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    @PostMapping(value = "/register", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
+    @PostMapping(value = "/register", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE})
     @Operation(summary = "가게 입점 등록", description = """
-        S3에 미리 업로드된 파일 URL을 기반으로 가게 입점 정보를 등록합니다.
-        """)
+            S3에 미리 업로드된 파일 URL을 기반으로 가게 입점 정보를 등록합니다.
+            """)
     public ResponseEntity<ResponseTemplate<Object>> registerStore(
             @RequestPart("request") @Valid StoreRegisterRequest request,
             @RequestPart("businessLicenseFile") MultipartFile businessLicenseFile,
             @RequestPart("businessPermitFile") MultipartFile businessPermitFile,
             @AuthenticationPrincipal Long userId
     ) {
-        Long storeId = storeService.registerStore(request,userId,businessLicenseFile,businessPermitFile);
+        Long storeId = storeService.registerStore(request, userId, businessLicenseFile, businessPermitFile);
         return ResponseEntity
                 .ok(ResponseTemplate.from(storeId));
     }
@@ -61,7 +63,8 @@ public class StoreController {
 
     @Operation(summary = "가게 통합 검색", description = "page는 0부터 시작합니다. hasNext가 false이면 마지막 페이지입니다.<br><br>" +
             "입력받은 값 : keyword / 당일 주문 여부 : isSameDayOrder / 지역 리스트 : locationList (ex. 강남구, 중랑구) <br>" +
-            "시작일 : '2025-01-01' 형식으로 startDate / 종료일 : '2025-01-01' 형식으로 endDate (하루만 선택할 경우 시작일과 종료일을 같게 입력해주세요.) <br>" +
+            "시작일 : '2025-01-01' 형식으로 startDate / 종료일 : '2025-01-01' 형식으로 endDate (하루만 선택할 경우 시작일과 종료일을 같게 입력해주세요.) <br>"
+            +
             "최소 금액 : minPrice / 최대 금액 : maxPrice / 도시락 케이크 여부는 isLunchBoxCake 에 입력해주세요.")
     @GetMapping("/search")
     public ResponseEntity<ResponseTemplate<Object>> searchStore(
@@ -86,4 +89,17 @@ public class StoreController {
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(storeList));
     }
+
+    @Operation(summary = "스토어 상세 조회", description = "스토어 상세 정보를 조회합니다.<br>"
+            + "가게에서 설정한 모든 사이즈 정보도 이때 함께 응답합니다.")
+    @GetMapping("/detail/{storeId}")
+    public ResponseEntity<ResponseTemplate<Object>> getStoreDetail(
+            @PathVariable Long storeId
+    ) {
+        StoreDetailResponse storeDetail = storeService.getstoreDetail(storeId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseTemplate.from(storeDetail));
+    }
 }
+

--- a/src/main/java/com/deark/be/store/domain/Store.java
+++ b/src/main/java/com/deark/be/store/domain/Store.java
@@ -56,9 +56,6 @@ public class Store extends BaseTimeEntity {
     @Column(name = "chatting_url")
     private String chattingUrl;
 
-    @Column(name = "is_unmanned")
-    private Boolean isUnmanned;
-
     @Column(name = "is_same_day_order")
     private Boolean isSameDayOrder;
 
@@ -80,6 +77,9 @@ public class Store extends BaseTimeEntity {
     @Column(name = "max_daily_orders")
     private Integer maxDailyOrders;
 
+    @Column(name = "is_self_service")
+    private Boolean isSelfService;
+
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BusinessHours> businessHoursList = new ArrayList<>();
 
@@ -92,9 +92,9 @@ public class Store extends BaseTimeEntity {
     @Builder
     public Store(User user, String name, String description, String phone, String address,
                  String businessNumber, LocalDate establishDate, String imageUrl,
-                 Long averageResponseTime, String chattingUrl, Boolean isUnmanned, Boolean isSameDayOrder,
+                 Long averageResponseTime, String chattingUrl,  Boolean isSameDayOrder,
                  String settlementAccount, String businessLicenseUrl, String businessPermitUrl, String ownerName,
-                 String orderLink, Integer maxDailyOrders, List<BusinessHours> businessHoursList, List<Size> sizeList, List<Design> designList) {
+                 String orderLink, Integer maxDailyOrders, Boolean isSelfService, List<BusinessHours> businessHoursList, List<Size> sizeList, List<Design> designList) {
         this.user = user;
         this.name = name;
         this.description = description;
@@ -105,7 +105,6 @@ public class Store extends BaseTimeEntity {
         this.imageUrl = imageUrl;
         this.averageResponseTime = averageResponseTime;
         this.chattingUrl = chattingUrl;
-        this.isUnmanned = isUnmanned;
         this.isSameDayOrder = isSameDayOrder;
         this.settlementAccount = settlementAccount;
         this.businessLicenseUrl = businessLicenseUrl;
@@ -113,6 +112,7 @@ public class Store extends BaseTimeEntity {
         this.ownerName = ownerName;
         this.orderLink = orderLink;
         this.maxDailyOrders = maxDailyOrders;
+        this.isSelfService=isSelfService;
         this.businessHoursList = businessHoursList;
         this.sizeList = sizeList;
         this.designList = designList;
@@ -120,7 +120,7 @@ public class Store extends BaseTimeEntity {
 
     // Store 엔티티 내에 추가할 메서드
     public void updateBasicInfo(String name, String phone, String description, String address,
-                                String imageUrl, String chattingUrl, Boolean isUnmanned,
+                                String imageUrl, String chattingUrl, Boolean isSelfService,
                                 String orderLink, Integer maxDailyOrders) {
         this.name = name;
         this.phone = phone;
@@ -128,7 +128,7 @@ public class Store extends BaseTimeEntity {
         this.address = address;
         this.imageUrl = imageUrl;
         this.chattingUrl = chattingUrl;
-        this.isUnmanned = isUnmanned;
+        this.isSelfService = isSelfService;
         this.orderLink = orderLink;
         this.maxDailyOrders = maxDailyOrders;
     }

--- a/src/main/java/com/deark/be/store/domain/Store.java
+++ b/src/main/java/com/deark/be/store/domain/Store.java
@@ -92,9 +92,10 @@ public class Store extends BaseTimeEntity {
     @Builder
     public Store(User user, String name, String description, String phone, String address,
                  String businessNumber, LocalDate establishDate, String imageUrl,
-                 Long averageResponseTime, String chattingUrl,  Boolean isSameDayOrder,
+                 Long averageResponseTime, String chattingUrl, Boolean isSameDayOrder,
                  String settlementAccount, String businessLicenseUrl, String businessPermitUrl, String ownerName,
-                 String orderLink, Integer maxDailyOrders, Boolean isSelfService, List<BusinessHours> businessHoursList, List<Size> sizeList, List<Design> designList) {
+                 String orderLink, Integer maxDailyOrders, Boolean isSelfService, List<BusinessHours> businessHoursList,
+                 List<Size> sizeList, List<Design> designList) {
         this.user = user;
         this.name = name;
         this.description = description;
@@ -112,7 +113,7 @@ public class Store extends BaseTimeEntity {
         this.ownerName = ownerName;
         this.orderLink = orderLink;
         this.maxDailyOrders = maxDailyOrders;
-        this.isSelfService=isSelfService;
+        this.isSelfService = isSelfService;
         this.businessHoursList = businessHoursList;
         this.sizeList = sizeList;
         this.designList = designList;

--- a/src/main/java/com/deark/be/store/dto/request/StoreBasicInfoRequest.java
+++ b/src/main/java/com/deark/be/store/dto/request/StoreBasicInfoRequest.java
@@ -29,7 +29,7 @@ public record StoreBasicInfoRequest(
         @NotBlank String chattingUrl,
 
         @Schema(description = "무인 운영 여부", example = "false")
-        @NotNull Boolean isUnmanned,
+        @NotNull Boolean isSelfService,
 
         @Schema(description = "주문 링크", example = "https://order.example.com")
         @NotBlank String orderLink,
@@ -42,6 +42,6 @@ public record StoreBasicInfoRequest(
 
 ) {
         public void updateBasicInfo(Store store) {
-                store.updateBasicInfo(name,phone,description,address,imageUrl,chattingUrl,isUnmanned,orderLink,maxDailyOrders);
+                store.updateBasicInfo(name,phone,description,address,imageUrl,chattingUrl,isSelfService,orderLink,maxDailyOrders);
         }
 }

--- a/src/main/java/com/deark/be/store/dto/response/BusinessHourResponse.java
+++ b/src/main/java/com/deark/be/store/dto/response/BusinessHourResponse.java
@@ -1,0 +1,9 @@
+package com.deark.be.store.dto.response;
+
+
+public record BusinessHourResponse(
+        String dayName,
+        String openTime,
+        String closeTime
+) {
+}

--- a/src/main/java/com/deark/be/store/dto/response/PickUpHourResponse.java
+++ b/src/main/java/com/deark/be/store/dto/response/PickUpHourResponse.java
@@ -2,7 +2,9 @@ package com.deark.be.store.dto.response;
 
 import com.deark.be.store.domain.BusinessHours;
 import java.time.format.DateTimeFormatter;
+import lombok.Builder;
 
+@Builder
 public record PickUpHourResponse(
         String dayName,
         String startTime,
@@ -10,10 +12,10 @@ public record PickUpHourResponse(
 ) {
     public static PickUpHourResponse from(BusinessHours businessHours) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
-        return new PickUpHourResponse(
-                businessHours.getBusinessDay().getDayName(),
-                businessHours.getOpenTime().format(formatter),
-                businessHours.getCloseTime().format(formatter)
-        );
+        return PickUpHourResponse.builder()
+                .dayName(businessHours.getBusinessDay().getDayName())
+                .startTime(businessHours.getOpenTime().format(formatter))
+                .endTime(businessHours.getCloseTime().format(formatter))
+                .build();
     }
 }

--- a/src/main/java/com/deark/be/store/dto/response/PickUpHourResponse.java
+++ b/src/main/java/com/deark/be/store/dto/response/PickUpHourResponse.java
@@ -1,0 +1,19 @@
+package com.deark.be.store.dto.response;
+
+import com.deark.be.store.domain.BusinessHours;
+import java.time.format.DateTimeFormatter;
+
+public record PickUpHourResponse(
+        String dayName,
+        String startTime,
+        String endTime
+) {
+    public static PickUpHourResponse from(BusinessHours businessHours) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return new PickUpHourResponse(
+                businessHours.getBusinessDay().getDayName(),
+                businessHours.getOpenTime().format(formatter),
+                businessHours.getCloseTime().format(formatter)
+        );
+    }
+}

--- a/src/main/java/com/deark/be/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/deark/be/store/dto/response/StoreDetailResponse.java
@@ -1,5 +1,6 @@
 package com.deark.be.store.dto.response;
 
+import com.deark.be.store.domain.Store;
 import java.util.List;
 import lombok.Builder;
 
@@ -20,4 +21,30 @@ public record StoreDetailResponse(
         String businessNumber,
         List<String>sizeNameList
 ) {
+    public static StoreDetailResponse from(
+            Store store,
+            boolean is24hSelfService,
+            boolean isLunchBoxCake,
+            List<BusinessHourResponse> businessHours,
+            List<PickUpHourResponse> pickupHours,
+            Long likeCount,
+            List<String> sizeNameList
+    ) {
+        return new StoreDetailResponse(
+                store.getId(),
+                store.getName(),
+                store.getDescription(),
+                store.getImageUrl(),
+                store.getAddress(),
+                store.getIsSameDayOrder(),
+                is24hSelfService,
+                isLunchBoxCake,
+                businessHours,
+                pickupHours,
+                store.getOwnerName(),
+                likeCount,
+                store.getBusinessNumber(),
+                sizeNameList
+        );
+    }
 }

--- a/src/main/java/com/deark/be/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/deark/be/store/dto/response/StoreDetailResponse.java
@@ -1,0 +1,23 @@
+package com.deark.be.store.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record StoreDetailResponse(
+        Long storeId,
+        String storeName,
+        String storeDescription,
+        String storeImageUrl,
+        String storeAddress,
+        Boolean isSameDayOrder,
+        Boolean is24hSelfService,
+        Boolean isLunchBoxCake,
+        List<BusinessHourResponse>businessHours,
+        List<PickUpHourResponse>pickUpHours,
+        String ownerName,
+        Long likeCount,
+        String businessNumber,
+        List<String>sizeNameList
+) {
+}

--- a/src/main/java/com/deark/be/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/deark/be/store/dto/response/StoreDetailResponse.java
@@ -14,37 +14,40 @@ public record StoreDetailResponse(
         Boolean isSameDayOrder,
         Boolean is24hSelfService,
         Boolean isLunchBoxCake,
-        List<BusinessHourResponse>businessHours,
-        List<PickUpHourResponse>pickUpHours,
+        Boolean isBookmarkedInEvent,
+        List<BusinessHourResponse> businessHours,
+        List<PickUpHourResponse> pickUpHours,
         String ownerName,
         Long likeCount,
         String businessNumber,
-        List<String>sizeNameList
+        List<String> sizeNameList
 ) {
-    public static StoreDetailResponse from(
+    public static StoreDetailResponse of(
             Store store,
             boolean is24hSelfService,
             boolean isLunchBoxCake,
+            boolean isBookmarkedInEvent,
             List<BusinessHourResponse> businessHours,
             List<PickUpHourResponse> pickupHours,
             Long likeCount,
             List<String> sizeNameList
     ) {
-        return new StoreDetailResponse(
-                store.getId(),
-                store.getName(),
-                store.getDescription(),
-                store.getImageUrl(),
-                store.getAddress(),
-                store.getIsSameDayOrder(),
-                is24hSelfService,
-                isLunchBoxCake,
-                businessHours,
-                pickupHours,
-                store.getOwnerName(),
-                likeCount,
-                store.getBusinessNumber(),
-                sizeNameList
-        );
+        return StoreDetailResponse.builder()
+                .storeId(store.getId())
+                .storeName(store.getName())
+                .storeDescription(store.getDescription())
+                .storeImageUrl(store.getImageUrl())
+                .storeAddress(store.getAddress())
+                .isSameDayOrder(store.getIsSameDayOrder())
+                .is24hSelfService(is24hSelfService)
+                .isLunchBoxCake(isLunchBoxCake)
+                .isBookmarkedInEvent(isBookmarkedInEvent)
+                .businessHours(businessHours)
+                .pickUpHours(pickupHours)
+                .ownerName(store.getOwnerName())
+                .likeCount(likeCount)
+                .businessNumber(store.getBusinessNumber())
+                .sizeNameList(sizeNameList)
+                .build();
     }
 }

--- a/src/main/java/com/deark/be/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/deark/be/store/repository/StoreRepositoryImpl.java
@@ -132,7 +132,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                                         store.imageUrl,
                                         store.address,
                                         store.isSameDayOrder,
-                                        store.isUnmanned,
+                                        store.isSelfService,
                                         hasLunchBoxCakeSizeExpr,
                                         isLikedExpr,
                                         numberTemplate(

--- a/src/main/java/com/deark/be/store/repository/init/StoreInitializer.java
+++ b/src/main/java/com/deark/be/store/repository/init/StoreInitializer.java
@@ -51,7 +51,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("123-45-67890")
                     .establishDate(LocalDate.of(2020, 1, 1))
                     .imageUrl(storeImageUrl + "/blueberry.jpg")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(true)
                     .build();
 
@@ -64,7 +64,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("234-56-78901")
                     .establishDate(LocalDate.of(2021, 7, 2))
                     .imageUrl(storeImageUrl + "/birthday.jpg")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(false)
                     .build();
 
@@ -77,7 +77,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("345-67-89012")
                     .establishDate(LocalDate.of(2019, 5, 15))
                     .imageUrl(storeImageUrl + "/yellow.jpg")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(false)
                     .build();
 
@@ -90,7 +90,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("456-78-90123")
                     .establishDate(LocalDate.of(2023, 3, 10))
                     .imageUrl(storeImageUrl + "/star.jpg")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(true)
                     .build();
 
@@ -103,7 +103,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("567-89-01234")
                     .establishDate(LocalDate.of(2024, 8, 20))
                     .imageUrl(storeImageUrl + "/ribbon.jpg")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(false)
                     .build();
 
@@ -116,7 +116,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("678-90-12345")
                     .establishDate(LocalDate.of(2016, 12, 25))
                     .imageUrl(storeImageUrl + "/loopy.png")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(true)
                     .build();
 
@@ -129,7 +129,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("789-01-23456")
                     .establishDate(LocalDate.of(2019, 11, 30))
                     .imageUrl(storeImageUrl + "/blackpink.png")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(false)
                     .build();
 
@@ -142,7 +142,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("791-02-34567")
                     .establishDate(LocalDate.of(2020, 4, 5))
                     .imageUrl(storeImageUrl + "/whiteblack.png")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(true)
                     .build();
 
@@ -155,7 +155,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("792-03-45678")
                     .establishDate(LocalDate.of(2021, 2, 14))
                     .imageUrl(storeImageUrl + "/muffin.png")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(false)
                     .build();
 
@@ -168,7 +168,7 @@ public class StoreInitializer implements ApplicationRunner {
                     .businessNumber("793-04-56789")
                     .establishDate(LocalDate.of(2022, 9, 9))
                     .imageUrl(storeImageUrl + "/pink.png")
-                    .isUnmanned(false)
+                    .isSelfService(false)
                     .isSameDayOrder(true)
                     .build();
 

--- a/src/main/java/com/deark/be/store/service/StoreService.java
+++ b/src/main/java/com/deark/be/store/service/StoreService.java
@@ -1,12 +1,18 @@
 package com.deark.be.store.service;
 
+import com.deark.be.design.repository.SizeRepository;
+import com.deark.be.event.repository.EventStoreRepository;
 import com.deark.be.global.service.S3Service;
+import com.deark.be.store.domain.BusinessHours;
 import com.deark.be.store.domain.Store;
 import com.deark.be.store.domain.type.SortType;
 import com.deark.be.store.dto.request.StoreBasicInfoRequest;
 import com.deark.be.store.dto.request.StoreRegisterRequest;
+import com.deark.be.store.dto.response.BusinessHourResponse;
+import com.deark.be.store.dto.response.PickUpHourResponse;
 import com.deark.be.store.dto.response.SearchStorePagedResult;
 import com.deark.be.store.dto.response.SearchStoreResponseList;
+import com.deark.be.store.dto.response.StoreDetailResponse;
 import com.deark.be.store.exception.StoreException;
 import com.deark.be.store.repository.StoreRepository;
 import com.deark.be.user.domain.User;
@@ -33,7 +39,9 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
     private final BusinessHoursService businessHoursService;
+    private final SizeRepository sizeRepository;
     private final S3Service s3Service;
+    private final EventStoreRepository eventStoreRepository;
 
     @Transactional
     public Long registerStore(StoreRegisterRequest request, Long userId, MultipartFile businessLicenseFile, MultipartFile businessPermitFile) {
@@ -63,5 +71,38 @@ public class StoreService {
                 keyword, isSameDayOrder, locationList, startDate, endDate, minPrice, maxPrice, isLunchBoxCake);
 
         return SearchStoreResponseList.of(allSearchResult.totalCount(), page, allSearchResult.hasNext(), allSearchResult.storeList());
+    }
+
+    public StoreDetailResponse getstoreDetail(Long storeId) {
+        List <String> sizeNameList=sizeRepository.findSizeNamesByStoreId(storeId);
+        Long likeCount=eventStoreRepository.countByStoreId(storeId);
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(STORE_NOT_FOUND));
+
+        boolean is24hSelfService = Boolean.TRUE.equals(store.getIsSelfService()) &&
+                store.getBusinessHoursList().stream()
+                        .anyMatch(BusinessHours::getIsOpen24Hours);
+
+        boolean isLunchBoxCake = sizeRepository.existsByStoreIdAndNameContaining(storeId, "도시락");
+
+        List<PickUpHourResponse> pickupHours  = store.getBusinessHoursList().stream()
+                .map(PickUpHourResponse::from)
+                .toList();
+
+        List<BusinessHourResponse> businessHours=pickupHours.stream()
+                .map(p->new BusinessHourResponse(p.dayName(),p.startTime(),p.endTime()))
+                .toList();
+
+
+
+        return  StoreDetailResponse.from(
+                store,
+                is24hSelfService,
+                isLunchBoxCake,
+                businessHours,
+                pickupHours,
+                likeCount,
+                sizeNameList
+        );
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #36 

## 📝작업 내용
가게 상세 조회 api 개발 - 가게 상세 조회api 응답 시 가게에서 설정한 모든 사이즈도 함께 반환하도록 구현
SecurityConfig에 CORS 설정 추가 - 프론트엔드(localhost:3000) Origin 허용

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ea129265-8b4e-4f68-a04a-edb1cbab4d31)

user가 해당 스토어를 찜했는지 여부를 isBookmarkedInEvent로 반환하도록 추가 구현하였습니다! 
![image](https://github.com/user-attachments/assets/49b2c559-7533-468a-9149-5dff7bee1c3f)

## 💬리뷰 요구사항(선택)

> SecurityConfig에 CORS 설정 추가하였습니다! 확인 부탁드립니다.
