### PR TITLE
[FEAT] 가게별 디자인목록 조회 API + 주문서 생성 로직 수정

### DIFF
--- a/src/main/java/com/deark/be/design/controller/DesignController.java
+++ b/src/main/java/com/deark/be/design/controller/DesignController.java
@@ -97,4 +97,14 @@ public class DesignController {
                 .status(HttpStatus.OK)
                 .body(ResponseTemplate.from(designDetail));
     }
+
+    @Operation(summary = "주문서 작성 화면의 \"디자인 선택\" 용 조회 ", description = "주문서 작성 화면의 \"디자인 선택\" 드롭다운 또는 리스트용 데이터만 제공합니다.")
+    @GetMapping("/store/{storeId}/select")
+    public ResponseEntity<ResponseTemplate<List<StoreDesignSimpleResponse>>> getDesignListForOrderSelect(
+            @PathVariable Long storeId
+    ) {
+
+        List<StoreDesignSimpleResponse> designList = designService.getSimpleDesignListByStoreId(storeId);
+        return ResponseEntity.ok(ResponseTemplate.from(designList));
+    }
 }

--- a/src/main/java/com/deark/be/design/dto/response/StoreDesignSimpleResponse.java
+++ b/src/main/java/com/deark/be/design/dto/response/StoreDesignSimpleResponse.java
@@ -11,12 +11,12 @@ public record StoreDesignSimpleResponse(
         @Schema(description = "디자인 이름", example = "레인보우케이크")
         String designName,
         @Schema(description = "디자인 이미지 URL", example = "https://cdn.deark.com/designs/rainbow.png")
-        String imageUrl,
+        String designImageUrl,
         @Schema(description = "디자인 가격", example = "19000")
         Long price
 ) {
-    public static StoreDesignResponse from(Design design) {
-        return StoreDesignResponse.builder()
+    public static StoreDesignSimpleResponse from(Design design) {
+        return StoreDesignSimpleResponse.builder()
                 .designId(design.getId())
                 .designName(design.getName())
                 .designImageUrl(design.getImageUrl())

--- a/src/main/java/com/deark/be/design/dto/response/StoreDesignSimpleResponse.java
+++ b/src/main/java/com/deark/be/design/dto/response/StoreDesignSimpleResponse.java
@@ -1,0 +1,26 @@
+package com.deark.be.design.dto.response;
+
+import com.deark.be.design.domain.Design;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record StoreDesignSimpleResponse(
+        @Schema(description = "디자인 ID", example = "1")
+        Long designId,
+        @Schema(description = "디자인 이름", example = "레인보우케이크")
+        String designName,
+        @Schema(description = "디자인 이미지 URL", example = "https://cdn.deark.com/designs/rainbow.png")
+        String imageUrl,
+        @Schema(description = "디자인 가격", example = "19000")
+        Long price
+) {
+    public static StoreDesignResponse from(Design design) {
+        return StoreDesignResponse.builder()
+                .designId(design.getId())
+                .designName(design.getName())
+                .designImageUrl(design.getImageUrl())
+                .price(design.getPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/deark/be/design/repository/DesignRepository.java
+++ b/src/main/java/com/deark/be/design/repository/DesignRepository.java
@@ -13,4 +13,6 @@ public interface DesignRepository extends JpaRepository<Design, Long>, DesignRep
 
     @Query("SELECT d.id FROM Design d LEFT JOIN d.eventDesignList ed GROUP BY d.id ORDER BY COUNT(ed) DESC")
     List<Long> findTopDesignIds(Pageable pageable);
+
+    List<Design> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/deark/be/design/service/DesignService.java
+++ b/src/main/java/com/deark/be/design/service/DesignService.java
@@ -87,4 +87,16 @@ public class DesignService {
         return designRepository.findById(designId)
                 .orElseThrow(() -> new DesignException(DESIGN_NOT_FOUND));
     }
+
+    public List<StoreDesignSimpleResponse> getSimpleDesignListByStoreId(Long storeId) {
+        List<Design> designs = designRepository.findByStoreId(storeId);
+        return designs.stream()
+                .map(design -> StoreDesignSimpleResponse.builder()
+                        .designId(design.getId())
+                        .designName(design.getName())
+                        .imageUrl(design.getImageUrl())
+                        .price(design.getPrice())
+                        .build())
+                .toList();
+    }
 }

--- a/src/main/java/com/deark/be/design/service/DesignService.java
+++ b/src/main/java/com/deark/be/design/service/DesignService.java
@@ -91,12 +91,7 @@ public class DesignService {
     public List<StoreDesignSimpleResponse> getSimpleDesignListByStoreId(Long storeId) {
         List<Design> designs = designRepository.findByStoreId(storeId);
         return designs.stream()
-                .map(design -> StoreDesignSimpleResponse.builder()
-                        .designId(design.getId())
-                        .designName(design.getName())
-                        .imageUrl(design.getImageUrl())
-                        .price(design.getPrice())
-                        .build())
+                .map(StoreDesignSimpleResponse::from)
                 .toList();
     }
 }

--- a/src/main/java/com/deark/be/order/controller/OrderController.java
+++ b/src/main/java/com/deark/be/order/controller/OrderController.java
@@ -7,17 +7,21 @@ import com.deark.be.order.service.OrderQuestionService;
 import com.deark.be.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Order", description = "주문 관련 API")
 @Slf4j
@@ -51,12 +55,15 @@ public class OrderController {
         - requestDetailType이 `CUSTOM`인 경우(= 사용자 갤러리에서 선택): requestDetailImageUrl 필수, requestDetailDesignId은 null로 설정해주세요.
 
         """)
-    @PostMapping("/submit")
+    @PostMapping(value="/submit", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE,
+            MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<ResponseTemplate<Long>> submitOrder(
             @AuthenticationPrincipal Long userId,
-            @RequestBody SubmitOrderRequest request) {
+            @RequestPart("request") @Valid SubmitOrderRequest request,
+            @RequestPart(value = "designImage",required = false) MultipartFile designImage,
+            @RequestPart(value = "requestDetailImage",required = false) MultipartFile requestDetailImage) {
 
-        Long messageId = orderService.submitOrder(request, userId);
+        Long messageId = orderService.submitOrder(request, userId,designImage,requestDetailImage);
         return ResponseEntity.ok(ResponseTemplate.from(messageId));
     }
 }

--- a/src/main/java/com/deark/be/order/dto/request/SubmitOrderRequest.java
+++ b/src/main/java/com/deark/be/order/dto/request/SubmitOrderRequest.java
@@ -5,16 +5,12 @@ import com.deark.be.order.domain.Message;
 import com.deark.be.order.domain.type.DesignType;
 import com.deark.be.order.domain.type.RequestDetailType;
 import com.deark.be.order.domain.type.Status;
-import com.deark.be.order.exception.OrderException;
-import com.deark.be.order.exception.errorcode.OrderErrorCode;
 import com.deark.be.store.domain.Store;
 import com.deark.be.user.domain.User;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+
 public record SubmitOrderRequest(
         @Schema(description = "주문 대상 가게 ID", example = "1")
         Long storeId,
@@ -25,22 +21,16 @@ public record SubmitOrderRequest(
         @Schema(description = "디자인 ID (designType이 STORE일 경우 사용)", example = "1")
         Long designId,
 
-        @Schema(description = "사용자가 직접 업로드한 디자인 이미지 URL (designType이 CUSTOM일 경우 사용)")
-        String designUrl,
-
         @Schema(description = "추가 요청사항 이미지 선택 유형 (EVENT: 사용자가 찜한 디자인, CUSTOM: 사용자 업로드)", example = "CUSTOM")
         RequestDetailType requestDetailType,
 
         @Schema(description = "추가 요청사항 이미지의 디자인 ID (requestDetailType이 EVENT일 경우 사용)")
         Long requestDetailDesignId,
 
-        @Schema(description = "추가 요청사항 직접 업로드 이미지 URL (requestDetailType이 CUSTOM일 경우 사용)", example = "https://image.bucket.com/request.jpg")
-        String requestDetailImageUrl,
-
         @Schema(description = "질문 및 답변 리스트")
         List<QARequest> answers
 ) {
-    public Message toEntity(User user, Store store, Design design, Design requestDetailDesign) {
+    public Message toEntity(User user, Store store, Design design, Design requestDetailDesign, String requestDetailImageUrl, String designUrl) {
         return Message.builder()
                 .user(user)
                 .store(store)
@@ -52,29 +42,5 @@ public record SubmitOrderRequest(
                 .requestDetailImageUrl(requestDetailImageUrl)
                 .status(Status.PENDING)
                 .build();
-    }
-
-    public void validateDesignParams() {
-        if (designType == DesignType.STORE) {
-            if (designId == null || designUrl != null) {
-                throw new OrderException(OrderErrorCode.INVALID_STORE_DESIGN_CONFLICT);
-            }
-        } else if (designType == DesignType.CUSTOM) {
-            if (designUrl == null || designUrl.isBlank() || designId != null) {
-                throw new OrderException(OrderErrorCode.INVALID_CUSTOM_DESIGN_CONFLICT);
-            }
-        }
-    }
-
-    public void validateRequestDetailParams() {
-        if (requestDetailType == RequestDetailType.EVENT) {
-            if (requestDetailDesignId == null || requestDetailImageUrl != null) {
-                throw new OrderException(OrderErrorCode.INVALID_EVENT_REQUEST_DETAIL_CONFLICT);
-            }
-        } else if (requestDetailType == RequestDetailType.CUSTOM) {
-            if (requestDetailImageUrl == null || requestDetailImageUrl.isBlank() || requestDetailDesignId != null) {
-                throw new OrderException(OrderErrorCode.INVALID_CUSTOM_REQUEST_DETAIL_CONFLICT);
-            }
-        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #47 

## 📝작업 내용
주문서 작성 화면에서 디자인 선택할 수 있도록 주문서용 디자인목록 조회 API 추가
주문서 작성 시 사용자가 직접 이미지를 업로드할 수 있도록 주문서 제출 API 수정
designType 및 requestDetailType에 따라 이미지가 적절하게 들어왔는지 검증하는 메소드를 OrderService 내부로 이동


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/65819431-bb9c-4ea7-a4a1-7d739d82aa0a)
![image](https://github.com/user-attachments/assets/f7d8d602-28d7-4c80-9143-52bf172cf239)
